### PR TITLE
Fix Appveyor CI failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,13 @@ environment:
 
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda info --all
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+  - cmd: activate # important: activate the base once!
+  - cmd: conda init cmd.exe
   - "conda create -q -n test-environment python=3.6"
-  - activate test-environment
+  - cmd: activate test-environment
   - pip install https://github.com/worldbank/ML-classification-algorithms-poverty/raw/master/deps/xgboost-0.71-cp36-cp36m-win_amd64.whl
   - pip install -r requirements-dev.txt
   - pip install .[cpu]


### PR DESCRIPTION
Since the last commit (ba303ce), there have been changes to appveyor, conda, or some combination of the two that causes our build to fail with the error
```
TypeError: LoadLibrary() argument 1 must be str, not None
```

I found some discussion of the error here, https://github.com/conda/conda/issues/8836 . It doesn't give a clear answer though.

I was able to find a fix here:
https://github.com/TUW-GEO/pytesmo/pull/164/files#diff-180360612c6b8c4ed830919bbb4dd459

Although geopandas might have another solution here:
https://github.com/geopandas/geopandas/blob/master/appveyor.yml

Full disclosure: I have no idea how this fix works or how appveyor works. But I will say that this change makes the red x turn into a green dot.