### PR TITLE
Object recognition

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+---
+name: Pull Request
+about: Request merging changes into the code base
+title: ''
+labels: ''
+reviewers: ''
+
+---
+
+## Description
+
+
+## Tests
+*Due to the long run times and large memory requirements, some tests cannot be completed on our CI platform. Those tests should be marked with `@pytest.skipif(zamba.config.codetree)` decorator. Run the tests locally using `pytest zamba` and paste the output below.*

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ docs/_build/
 drivendataorg_chimps-tool.aes
 output
 output.old
+*.aes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for CI on codeship
-FROM continuumio/anaconda3:5.2.0
+FROM python:3.6-stretch
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && \
@@ -9,7 +9,6 @@ RUN apt-get update && \
 	libavutil-dev libavfilter-dev libswscale-dev libswresample-dev \
 	unzip pkg-config && \
 	rm -rf /var/lib/apt/lists/*
-RUN pip install -U pip Cython
 
 # download weights
 RUN mkdir -p /root/.cache/zamba/cnnensemble /root/.cache/zamba/megadetector /root/.keras/models && \
@@ -37,7 +36,9 @@ COPY zamba/models/cnnensemble/requirements.txt /app/zamba/models/cnnensemble
 COPY docs/requirements.txt /app/docs
 
 WORKDIR /app
-RUN pip install -r requirements-dev.txt
+RUN pip install -U pip Cython && \
+	pip install -r requirements-dev.txt && \
+	rm -rf /root/.cache/pip
 
 COPY . /app
 RUN pip install .[cpu]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,33 +2,38 @@
 FROM continuumio/anaconda3:5.2.0
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update && apt-get install -y build-essential
-
-RUN apt-get install -y --allow-unauthenticated ffmpeg
-RUN apt-get install -y unzip
+RUN apt-get update && \
+	apt-get install -y build-essential && \
+	apt-get install -y --allow-unauthenticated ffmpeg && \
+	apt-get install -y libavformat-dev libavcodec-dev libavdevice-dev \
+	libavutil-dev libavfilter-dev libswscale-dev libswresample-dev \
+	unzip pkg-config && \
+	rm -rf /var/lib/apt/lists/*
 RUN pip install -U pip Cython
 
 # download weights
-RUN mkdir -p /app/zamba/models/cnnensemble
-RUN wget https://s3.amazonaws.com/drivendata-public-assets/zamba.zip -P /tmp && \
-	unzip /tmp/zamba.zip -d /app/zamba/models/cnnensemble
-RUN wget https://s3.amazonaws.com/drivendata-public-assets/data_fast.zip -P /tmp && \
-	unzip /tmp/data_fast.zip -d /app/zamba/models/cnnensemble
-RUN wget https://s3.amazonaws.com/drivendata-public-assets/input.tar.gz -P /tmp && \
-	tar xvzf /tmp/input.tar.gz -C /app/zamba/models/cnnensemble/
+RUN mkdir -p /root/.cache/zamba/cnnensemble /root/.cache/zamba/megadetector /root/.keras/models && \
+	wget https://s3.amazonaws.com/drivendata-public-assets/zamba.zip -P /tmp && \
+	unzip -q /tmp/zamba.zip -d /root/.cache/zamba/cnnensemble && \
+	wget https://s3.amazonaws.com/drivendata-public-assets/data_fast.zip -P /tmp && \
+	unzip -q /tmp/data_fast.zip -d /root/.cache/zamba/cnnensemble && \
+	wget https://s3.amazonaws.com/drivendata-public-assets/input.tar.gz -P /tmp && \
+	tar xzf /tmp/input.tar.gz -C /root/.cache/zamba/cnnensemble/ && \
+	wget https://drivendata-public-assets.s3.amazonaws.com/zamba-and-obj-rec-0.859.joblib \
+		-P /root/.cache/zamba/blanknonblank && \
+	wget https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/megadetector_v3.pb \
+		-P /root/.cache/zamba/megadetector && \
+	wget https://github.com/fchollet/deep-learning-models/releases/download/v0.8/NASNet-mobile-no-top.h5 \
+		-O /root/.keras/models/nasnet_mobile_no_top.h5 && \
+	wget https://github.com/fchollet/deep-learning-models/releases/download/v0.7/inception_resnet_v2_weights_tf_dim_ordering_tf_kernels_notop.h5 \
+		-P /root/.keras/models && \
+	wget https://github.com/fchollet/deep-learning-models/releases/download/v0.5/inception_v3_weights_tf_dim_ordering_tf_kernels_notop.h5 \
+		-P /root/.keras/models && \
+	rm /tmp/zamba.zip /tmp/input.tar.gz /tmp/data_fast.zip
 
-RUN mkdir -p ~/.keras/models
-RUN wget https://github.com/fchollet/deep-learning-models/releases/download/v0.8/NASNet-mobile-no-top.h5 \
-	-O /root/.keras/models/nasnet_mobile_no_top.h5
-RUN wget https://github.com/fchollet/deep-learning-models/releases/download/v0.7/inception_resnet_v2_weights_tf_dim_ordering_tf_kernels_notop.h5 \
-	-O /root/.keras/models/inception_resnet_v2_weights_tf_dim_ordering_tf_kernels_notop.h5
-RUN wget https://github.com/fchollet/deep-learning-models/releases/download/v0.5/inception_v3_weights_tf_dim_ordering_tf_kernels_notop.h5  \
-	-O /root/.keras/models/inception_v3_weights_tf_dim_ordering_tf_kernels_notop.h5
-
-
+RUN mkdir -p /app/zamba/models/cnnensemble /app/docs
 COPY requirements-dev.txt requirements.txt /app/
 COPY zamba/models/cnnensemble/requirements.txt /app/zamba/models/cnnensemble
-RUN mkdir /app/docs
 COPY docs/requirements.txt /app/docs
 
 WORKDIR /app

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,5 +168,3 @@ todo_include_todos = True
 
 def setup(app):
     app.add_stylesheet('zamba_custom.css')
-
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,6 @@ sphinx_rtd_theme==0.3.0
 
 # required to autobuild docs, but only installed as extra
 tensorflow==1.10
+setuptools==39.1.0
 
 -r ../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest==3.4.2
 pytest-cov==2.5.1
 pytest-mock==1.7.1
-setuptools==39.1.0
 twine==1.11.0
 
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,15 @@
+appdirs==1.4.3
+av==6.2.0
 click==6.7
 ffmpy==0.2.2
 flake8==3.5.0
 h5py==2.7.1
+joblib==0.13.2
 matplotlib==2.1.2
 numpy==1.14.1
 pandas==0.22.0
 protobuf==3.6.0
-scikit-learn==0.19.1
+scikit-learn==0.21.2
 Sphinx==1.7.0
 sphinx_rtd_theme==0.3.0
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=requirements,
     extras_require={
         "cpu": ["tensorflow==1.10"],
-        "gpu": ["tensorflow-gpu==1.10"]
+        "gpu": ["tensorflow-gpu==1.10", "setuptools==39.1.0"]
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=requirements,
     extras_require={
         "cpu": ["tensorflow==1.10"],
-        "gpu": ["tensorflow-gpu==1.10", "setuptools==39.1.0"]
+        "gpu": ["tensorflow-gpu==1.10"]
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,8 @@ setup(
     python_requires='>=3.5',
     install_requires=requirements,
     extras_require={
-        "cpu": ["tensorflow==1.10"],
-        "gpu": ["tensorflow-gpu==1.10"]
+        "cpu": ["tensorflow==1.10", "setuptools==39.1.0"],
+        "gpu": ["tensorflow-gpu==1.10", "setuptools==39.1.0"]
     },
     entry_points={
         'console_scripts': [

--- a/zamba/__init__.py
+++ b/zamba/__init__.py
@@ -17,3 +17,6 @@ with warnings.catch_warnings():
 # set tensorflow logging to ignore warnings for deprecated alias `normal` for `truncated_normal`. Warning arises from
 # within keras that is packaged inside of tensorflow
 tensorflow.logging.set_verbosity(tensorflow.logging.ERROR)
+
+import zamba.config
+import zamba.utils

--- a/zamba/__init__.py
+++ b/zamba/__init__.py
@@ -1,5 +1,8 @@
 # avoid using a backend when not installed
 # as a framework.
+import zamba.config
+import zamba.utils  # noqa: F401
+
 import matplotlib
 matplotlib.use('Agg')
 
@@ -17,6 +20,3 @@ with warnings.catch_warnings():
 # set tensorflow logging to ignore warnings for deprecated alias `normal` for `truncated_normal`. Warning arises from
 # within keras that is packaged inside of tensorflow
 tensorflow.logging.set_verbosity(tensorflow.logging.ERROR)
-
-import zamba.config
-import zamba.utils

--- a/zamba/config.py
+++ b/zamba/config.py
@@ -17,4 +17,4 @@ else:
 
 cache_dir.mkdir(exist_ok=True)
 
-codeship = os.getenv("CI_NAME", False) == "codeship"
+codeship = os.getenv("CI", False)

--- a/zamba/config.py
+++ b/zamba/config.py
@@ -16,3 +16,5 @@ else:
     cache_dir = Path(cache_dir)
 
 cache_dir.mkdir(exist_ok=True)
+
+codeship = os.getenv("CI_NAME", False) == "codeship"

--- a/zamba/config.py
+++ b/zamba/config.py
@@ -17,4 +17,4 @@ else:
 
 cache_dir.mkdir(exist_ok=True)
 
-codeship = os.getenv("CI", False)
+codeship = os.getenv("CI", "false") == "true"

--- a/zamba/config.py
+++ b/zamba/config.py
@@ -1,0 +1,18 @@
+import appdirs
+import os
+import logging
+from pathlib import Path
+
+log_levels = {None: logging.WARNING, True: logging.DEBUG}
+
+cache_dir = os.getenv(
+    "ZAMBA_CACHE_DIR",
+    None
+)
+if cache_dir is None:
+    cache_dir = appdirs.user_cache_dir()
+    cache_dir = Path(cache_dir) / "zamba"
+else:
+    cache_dir = Path(cache_dir)
+
+cache_dir.mkdir(exist_ok=True)

--- a/zamba/convert_videos.py
+++ b/zamba/convert_videos.py
@@ -69,7 +69,7 @@ def convert_videos(
 
     for input_path, output_path in tqdm(
         zip(input_paths, output_paths),
-        total=len(input_paths),
+        total=len(output_paths),
         desc="Resampling videos",
     ):
         ffmpeg_resample(input_path, output_path, fps, width, height)

--- a/zamba/convert_videos.py
+++ b/zamba/convert_videos.py
@@ -1,0 +1,144 @@
+import click
+import logging
+from pathlib import Path
+from subprocess import check_output, CalledProcessError, STDOUT
+from tqdm import tqdm
+
+from zamba.config import log_levels
+from zamba.utils import unique_processed_paths
+
+
+def ffmpeg_resample(
+    input_file,
+    output_file,
+    fps,
+    width,
+    height,
+):
+    if output_file.exists():
+        return output_file
+
+    command = [
+        'ffmpeg',
+        '-y',
+        '-i', str(input_file),
+        '-r', str(fps),  # frame rate
+        '-c:v', 'libx264',  # use H264 codec
+        "-an",  # drop audio stream
+        '-crf', '20',  # H264 constant rate factor (0 lossless - 51 worst possible quality)
+        '-strict', '-6',
+        '-vf', (
+            f"""scale=w={width}:h={height}:force_original_aspect_ratio=1,"""
+            f"""pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,"""
+            """histeq"""
+        ),
+        str(output_file),
+    ]
+
+    try:
+        check_output(command, stderr=STDOUT)
+        logging.debug("Created %s", str(output_file))
+
+    except CalledProcessError as e:
+        logging.debug(e.output)
+
+    return output_file
+
+
+def convert_videos(
+    input_paths,
+    output_directory,
+    fps,
+    width,
+    height,
+):
+    """Converts videos to a standard resolution and frame rate and saves to disk
+
+    Args:
+        input_paths (list of str or Path): A list of paths to the input files
+        output_directory (str or Path): Path to an output directory
+        fps (float)
+        width (int)
+        height (int)
+
+    Returns:
+        list of Path: A list of output paths
+    """
+    output_directory.mkdir(exist_ok=True)
+    output_paths = unique_processed_paths(input_paths, output_directory)
+
+    for input_path, output_path in tqdm(
+        zip(input_paths, output_paths),
+        total=len(input_paths),
+        desc="Resampling videos",
+    ):
+        ffmpeg_resample(input_path, output_path, fps, width, height)
+
+    return output_paths
+
+
+@click.command()
+@click.option(
+    "--input_path",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to a list of file names to be processed",
+)
+@click.option(
+    "--output_directory",
+    type=click.Path(),
+    required=True,
+    help="Directory where the output will be saved",
+)
+@click.option(
+    "--fps",
+    default=15,
+    type=int,
+    help="Output frames per second",
+)
+@click.option(
+    "--width",
+    default=448,
+    type=int,
+    help="Width of output video",
+)
+@click.option(
+    "--height",
+    default=252,
+    type=int,
+    help="Height of output video",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    type=bool,
+    help="Output debug messages",
+)
+def run(
+    input_path,
+    output_directory,
+    fps,
+    width,
+    height,
+    verbose,
+):
+    logging.basicConfig(
+        level=log_levels[verbose],
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    input_path = Path(input_path)
+    output_directory = Path(output_directory)
+
+    if input_path.is_dir():
+        input_files = sorted(list(input_path.glob("**/*")))
+    else:
+        with input_path.open("r") as f:
+            input_files = [Path(line.strip("\n")) for line in f.readlines()]
+
+    convert_videos(input_files, output_directory, fps=fps, width=width, height=height)
+
+
+if __name__ == "__main__":
+    run()

--- a/zamba/models/blanknonblank.py
+++ b/zamba/models/blanknonblank.py
@@ -1,0 +1,87 @@
+import joblib
+
+from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.model_selection import GridSearchCV
+from tensorflow.python.keras.utils import get_file
+
+import zamba
+
+
+class BlankNonBlank():
+    MODEL_URL = "https://drivendata-public-assets.s3.amazonaws.com/zamba-and-obj-rec-0.859.joblib"
+    FEATURE_NAMES = [
+        "n_key_frames", "h", "w", "n_detections", "total_area", "bird", "cattle", "chimpanzee", "elephant",
+        "forest buffalo", "gorilla", "hippopotamus", "human", "hyena", "large ungulate", "leopard", "lion",
+        "other (non-primate)", "other (primate)", "pangolin", "porcupine", "reptile", "rodent", "small antelope",
+        "small cat", "wild dog", "duiker", "hog", "blank",
+    ]
+
+    def __init__(
+        self,
+        model_path=None,
+    ):
+        if model_path is None:
+            model_path = self._get_model()
+
+        self.model = self.load_model(str(model_path))
+
+    def fit(self, X, y):
+        model = GridSearchCV(
+            GradientBoostingClassifier(),
+            {
+                "loss": ["exponential", "deviance"],
+                "learning_rate": [0.001, 0.01, 0.1, 0.5],
+                "n_estimators": [100, 200, 300],
+                "subsample": [0.10, 0.25, 0.5],
+                "min_samples_split": [5, 10, 25],
+                "max_depth": [3, 5, 10],
+                "random_state": [1337],
+            },
+            verbose=2,
+            n_jobs=-1,
+            return_train_score=True,
+        )
+
+        model.fit(X, y)
+        return model
+
+    def prepare_features(self, features):
+        """Produces a feature array with the correct column ordering
+
+        Args:
+            features (pd.DataFrame): A table of features containing the columns in `BlankNonBlank.FEATURE_NAMES`
+
+        Returns:
+            np.ndarray: An array of features with shape (num samples, num features)
+        """
+        return features[self.FEATURE_NAMES].values
+
+    def predict(self, X):
+        return self.model.predict(X)
+
+    def load_model(self, model_path):
+        """
+        Load a model from a pickled file
+        """
+        with open(model_path, "rb") as f:
+            model = joblib.load(f)
+
+        return model
+
+    def _get_model(self, file_name="zamba-and-obj-rec-0.859.joblib", model_url=None):
+        if model_url is None:
+            model_url = self.MODEL_URL
+
+        cache_subdir = "blanknonblank"
+        model_path = zamba.config.cache_dir / cache_subdir / file_name
+
+        if not model_path.exists():
+            model_path = get_file(
+                fname=file_name,
+                origin=model_url,
+                cache_dir=zamba.config.cache_dir,
+                cache_subdir=cache_subdir,
+                extract=True,
+            )
+
+        return model_path

--- a/zamba/models/blanknonblank.py
+++ b/zamba/models/blanknonblank.py
@@ -59,6 +59,9 @@ class BlankNonBlank():
     def predict(self, X):
         return self.model.predict(X)
 
+    def predict_proba(self, X):
+        return self.model.predict_proba(X)
+
     def load_model(self, model_path):
         """
         Load a model from a pickled file

--- a/zamba/models/cnnensemble/requirements.txt
+++ b/zamba/models/cnnensemble/requirements.txt
@@ -17,7 +17,6 @@ pytz==2017.3
 PyWavelets==0.5.2
 PyYAML==3.12
 scikit-image==0.13.1
-scikit-learn==0.19.1
 scipy==1.0.0
 sk-video==1.1.10
 six==1.11.0

--- a/zamba/models/cnnensemble/src/config.py
+++ b/zamba/models/cnnensemble/src/config.py
@@ -1,11 +1,6 @@
-from os import getenv
-from pathlib import Path
+import zamba
 
-from dotenv import load_dotenv, find_dotenv
-
-load_dotenv(find_dotenv())
-
-MODEL_DIR = Path(__file__).parent.parent if getenv("ZAMBA_CACHE_DIR") is None else Path(getenv("ZAMBA_CACHE_DIR")) / "cnnensemble"
+MODEL_DIR = zamba.config.cache_dir / "cnnensemble"
 RAW_VIDEO_DIR = MODEL_DIR / "input" / "raw"
 TRAIN_IMG_DIR = MODEL_DIR / "data_fast" / "pri_matrix" / "train_img"
 TEST_VIDEO_DIR = MODEL_DIR / "input" / "raw_test"

--- a/zamba/models/cnnensemble/src/utils.py
+++ b/zamba/models/cnnensemble/src/utils.py
@@ -3,51 +3,6 @@ from contextlib import contextmanager
 import numpy as np
 import skvideo.io
 import skimage.transform
-from zamba.models.cnnensemble.src import config
-
-
-def validate_video(path, n_frames=1):
-    """Quickly checks whether a video file is valid by reading the first and last frames
-
-    Args:
-        path (str): Path to a video file
-        n_frames (int): Number of frames to load
-
-    Returns:
-        bool: True if video is valid, False if video is invalid
-    """
-    try:
-        video = skvideo.io.vreader(path)
-
-        for i in range(n_frames):
-            _ = next(video)
-
-        is_valid = True
-
-    except Exception:
-        is_valid = False
-
-    return is_valid
-
-
-def get_valid_videos(paths):
-    """Splits videos into valid and invalid
-
-    Args:
-        paths (list of str): A list of paths to videos
-
-    Returns:
-        A list of valid video paths and a list of invalid video paths
-    """
-    valid_videos, invalid_videos = [], []
-
-    for path in paths:
-        if validate_video(path):
-            valid_videos.append(path)
-        else:
-            invalid_videos.append(path)
-
-    return valid_videos, invalid_videos
 
 
 def preprocessed_input_to_img_resnet(x):

--- a/zamba/models/cnnensemble_model.py
+++ b/zamba/models/cnnensemble_model.py
@@ -85,7 +85,7 @@ class CnnEnsemble(Model):
 
         return OrderedDict(zip(input_paths, output_paths))
 
-    def predict(self, file_names):
+    def predict(self, file_names, resample=True):
         """Predict class probabilities for each input
 
         Args:
@@ -95,7 +95,7 @@ class CnnEnsemble(Model):
             pd.DataFrame: A table of class probabilities, where index is the file name and columns are the different
                 classes
         """
-        processed_paths = self.preprocess_videos(file_names)
+        processed_paths = self.preprocess_videos(file_names, resample=resample)
         valid_videos, invalid_videos = zamba.utils.get_valid_videos(processed_paths.values())
         self.logger.debug(f"Invalid videos {str(invalid_videos)}")
 
@@ -202,7 +202,7 @@ class CnnEnsemble(Model):
 
         bnb = BlankNonBlank()
         X = bnb.prepare_features(features)
-        blank = bnb.predict(X)
+        blank = bnb.predict_proba(X)[:, 1]
 
         blank = pd.Series(
             blank,

--- a/zamba/models/cnnensemble_model.py
+++ b/zamba/models/cnnensemble_model.py
@@ -1,4 +1,4 @@
-from collections import deque
+from collections import deque, OrderedDict
 from os import remove, getenv
 from pathlib import Path
 from shutil import rmtree
@@ -6,17 +6,21 @@ from dotenv import load_dotenv, find_dotenv
 import numpy as np
 import pandas as pd
 import logging
+import tempfile
 from tqdm import tqdm
 
 from tensorflow.python.keras.utils import get_file
 
-from zamba.models.model import Model
+import zamba
+from zamba.convert_videos import convert_videos
+from zamba.models.blanknonblank import BlankNonBlank
 from zamba.models.cnnensemble.src.single_frame_cnn import generate_prediction_test
 from zamba.models.cnnensemble.src import second_stage
 from zamba.models.cnnensemble.src import config
 from zamba.models.cnnensemble.src import prepare_train_data
 from zamba.models.cnnensemble.src import single_frame_cnn
-from zamba.models.cnnensemble.src import utils
+from zamba.models.mega_detector import MegaDetector
+from zamba.models.model import Model
 
 load_dotenv(find_dotenv())
 
@@ -46,40 +50,54 @@ class CnnEnsemble(Model):
             self._download_weights_if_needed(download_region)
 
     def load_data(self, data_path):
-        """ Loads data and returns it in a format that can be used
-            by this model. This is not recursive, and loads files that
-            do not start with ".".
+        input_paths = [
+            path for path in data_path.glob('**/*')
+            if not path.is_dir() and not path.name.startswith(".")
+        ]
+
+        return input_paths
+
+    def preprocess_videos(self, input_paths, resample=True):
+        """Preprocesses videos into a format that can be used by this model.
+
+        Input is a directory containing videos. The directory will be recursively searched for all files that do not
+        start with ".". Also has the option to resample raw videos to standard resolution and frame rate.
 
         Args:
-            data_path: A path to the input data
+            data_path (pathlib.Path): Path to a directory containing the input files
+            resample (bool): If true, resample the videos to a standard resolution and frame rate
 
         Returns:
-            The data.
+            OrderedDict: A dict with `key: value` as `original path: processed path` for each video.
         """
-        p = Path(data_path)
-        file_names = [x for x in p.glob('**/*') if x.is_file() and not x.name.startswith(".")]
-        return file_names
+        self.logger.debug("Preprocessing %d videos", len(input_paths))
+
+        if resample:
+            self.logger.debug("Converting videos to standard resolution and frame rate.")
+            output_directory = Path(
+                tempfile.mkdtemp(prefix="resampled_", dir=self.tempdir)
+            )
+            output_paths = convert_videos(
+                input_paths, output_directory, fps=15, width=448, height=252,
+            )
+        else:
+            output_paths = input_paths
+
+        return OrderedDict(zip(input_paths, output_paths))
 
     def predict(self, file_names):
-        """Predict class probabilities for each input, X
+        """Predict class probabilities for each input
 
         Args:
-            file_names: input data, list of video clip paths
+            file_names: input data, list of video paths
 
         Returns:
             pd.DataFrame: A table of class probabilities, where index is the file name and columns are the different
-            classes
+                classes
         """
-        valid_videos, invalid_videos = utils.get_valid_videos(file_names)
+        processed_paths = self.preprocess_videos(file_names)
+        valid_videos, invalid_videos = zamba.utils.get_valid_videos(processed_paths.values())
         self.logger.debug(f"Invalid videos {str(invalid_videos)}")
-
-        blank_file_names, blank_probabilities = self._find_blank_videos(valid_videos, threshold=0.5, dummy=False)
-        self.logger.debug(f"Blank videos {str(blank_file_names)}")
-
-        non_blank_file_names = sorted(
-            list(set(valid_videos) - blank_file_names)
-        )
-        self.logger.debug(f"Non-blank videos {str(non_blank_file_names)}")
 
         l1_results = {}
         prof = config.PROFILES[self.profile]
@@ -87,26 +105,28 @@ class CnnEnsemble(Model):
             l1_results[l1_model] = generate_prediction_test(
                 model_name=l1_model,
                 weights=config.MODEL_DIR / 'output' / config.MODEL_WEIGHTS[l1_model],
-                file_names=non_blank_file_names,
-                # verbose=self.verbose,
+                file_names=valid_videos,
                 save_results=False
             )
 
         l2_results = second_stage.predict(l1_results, profile=self.profile)
 
-        preds = pd.DataFrame(
+        cnn_features = pd.DataFrame(
             {
                 c: l2_results[:, i]
                 for i, c in enumerate(config.CLASSES)
             },
-            index=[str(file_name) for file_name in non_blank_file_names],
+            index=[str(file_name) for file_name in valid_videos],
             columns=config.CLASSES,
         )
+        cnn_features["blank"] = 0
+
+        blank = self.compute_blank_probability(valid_videos, cnn_features)
 
         # add nans for invalid videos
         preds = pd.concat(
             [
-                preds,
+                cnn_features,
                 pd.DataFrame(
                     np.nan,
                     index=[str(file_name) for file_name in invalid_videos],
@@ -116,12 +136,14 @@ class CnnEnsemble(Model):
             axis=0,
         )
 
-        # join with blank probabilities
-        preds = preds.drop(
-            columns=["blank"]
-        ).join(
-            blank_probabilities,
-            how="outer",
+        preds["blank"] = blank
+
+        preds.rename(
+            index={
+                str(processed_path): str(original_path)
+                for original_path, processed_path in processed_paths.items()
+            },
+            inplace=True,
         )
 
         return preds
@@ -156,38 +178,38 @@ class CnnEnsemble(Model):
                    fold=fold)
             single_frame_cnn.find_non_blank_frames(model_name=model_name, fold=fold)
 
-    def _find_blank_videos(self, file_names, threshold, dummy=False):
-        """Detects blank videos
+    def compute_blank_probability(self, video_paths, cnn_features):
+        """Predicts whether each video is blank
 
         Args:
-            file_names (list of str)
-            dummy (bool): If True, randomly assign blank probabilities. If False, assign a blank probability of 0 to
-                all videos
+            video_paths (list of str)
+            cnn_features (np.ndarray): Array of shape (num videos, num cnn categories) containing the output of the CNN
+                ensemble model
 
         Returns:
-            pd.Series: The probability that the video is blank for each video
+            pd.Series: A series containing the blank probability for each video
         """
+        mega = MegaDetector()
+        mega_features = mega.compute_features(video_paths)
 
-        def blank_nonblank_model(file_names):
-            rng = np.random.RandomState(100)
-            blank_probabilities = rng.rand(len(file_names))
-            return blank_probabilities
-
-        if dummy:
-            blank_probabilities = blank_nonblank_model(file_names)
-        else:
-            blank_probabilities = 0
-
-        blank_probabilities = pd.Series(
-            blank_probabilities,
-            index=[str(file_name) for file_name in file_names],
-            name="blank",
+        mega_features = pd.DataFrame(
+            mega_features,
+            index=[str(file_name) for file_name in video_paths],
+            columns=MegaDetector.FEATURE_NAMES,
         )
 
-        blank_file_names = blank_probabilities.loc[blank_probabilities > threshold].index
-        blank_file_names = set(Path(file_name) for file_name in blank_file_names)
+        features = pd.concat([mega_features, cnn_features], axis=1)
 
-        return blank_file_names, blank_probabilities
+        bnb = BlankNonBlank()
+        X = bnb.prepare_features(features)
+        blank = bnb.predict(X)
+
+        blank = pd.Series(
+            blank,
+            index=[str(path) for path in video_paths],
+        )
+
+        return blank
 
     def _train_l1_models(self):
         for model_name in config.PROFILES['full']:
@@ -309,7 +331,7 @@ class CnnEnsemble(Model):
         # file names, paths
         fnames = ["input.tar.gz", "zamba.zip", "data_fast.zip"]
 
-        cache_dir = Path(__file__).parent if getenv("ZAMBA_CACHE_DIR") is None else getenv("ZAMBA_CACHE_DIR")
+        cache_dir = zamba.config.cache_dir
         cache_subdir = Path("cnnensemble")
 
         paths_needed = [cache_dir / cache_subdir / "input",

--- a/zamba/models/manager.py
+++ b/zamba/models/manager.py
@@ -86,15 +86,8 @@ class ModelManager(object):
         Returns: DataFrame of predictions
 
         """
-
-        data_path = str(data_path)
-
-        # cnn ensemble doesn't use simple data loader, samples do...
-        if isinstance(self.model_class, CnnEnsemble):
-            preds = self.model.predict(data_path)
-        else:
-            data = self.model.load_data(data_path)
-            preds = self.model.predict(data)
+        data_paths = self.model.load_data(Path(data_path).expanduser().resolve())
+        preds = self.model.predict(data_paths)
 
         # threshold if provided
         if self.proba_threshold is not None:

--- a/zamba/models/manager.py
+++ b/zamba/models/manager.py
@@ -77,7 +77,7 @@ class ModelManager(object):
 
         self.verbose = verbose
 
-    def predict(self, data_path, save=False, pred_path=None):
+    def predict(self, data_path, save=False, pred_path=None, predict_kwargs=None):
         """
         Args:
             data_path (str | Path) : path to input data
@@ -86,8 +86,11 @@ class ModelManager(object):
         Returns: DataFrame of predictions
 
         """
+        if predict_kwargs is None:
+            predict_kwargs = dict()
+
         data_paths = self.model.load_data(Path(data_path).expanduser().resolve())
-        preds = self.model.predict(data_paths)
+        preds = self.model.predict(data_paths, **predict_kwargs)
 
         # threshold if provided
         if self.proba_threshold is not None:

--- a/zamba/models/mega_detector.py
+++ b/zamba/models/mega_detector.py
@@ -1,0 +1,290 @@
+from pathlib import Path
+
+import cv2
+import numpy as np
+import skimage.io
+import tensorflow as tf
+from tensorflow.python.keras.utils import get_file
+from tqdm import tqdm
+
+import zamba
+from zamba.utils import load_video
+import zamba.visualization as viz
+
+tf.logging.set_verbosity(tf.logging.ERROR)
+
+
+class MegaDetector:
+    """ Instantiate and detect on images or videos using AI for Earth's MegaDetector.
+
+        Read more documentation at https://github.com/microsoft/CameraTraps/blob/master/megadetector.md and download
+        the weights from https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/megadetector_v3.pb
+
+        Attributes:
+            model (tensorflow.python.framework.ops.Graph)
+            sess (tensorflow.python.client.session.Session)
+            confidence_threshold (float): Only keep bounding boxes with scores above this threshold
+    """
+    MODEL_URL = "https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/megadetector_v3.pb"
+    FEATURE_NAMES = ["n_key_frames", "h", "w", "n_detections", "total_area"]
+
+    def __init__(
+        self,
+        model_path=None,
+        confidence_threshold=0.85,
+    ):
+        """
+            Args:
+                model_path (str, optional): Path to mega detector weights (downloaded from
+                    https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/megadetector_v3.pb). If
+                    omitted, the weights will be downloaded automatically
+                confidence_threshold (float): Only keep bounding boxes with scores above this threshold
+        """
+        if model_path is None:
+            model_path = self._get_model()
+
+        self.model = self.load_model(str(model_path))
+        self.sess = tf.Session(graph=self.model)
+        self.confidence_threshold = confidence_threshold
+
+    def __del__(self):
+        if hasattr(self, "sess"):
+            self.sess.close()
+
+    def detect_image(self, image):
+        """
+        """
+        if isinstance(image, (str, Path)):
+            image = skimage.io.imread(image)
+
+        image_expanded = np.expand_dims(image, axis=0)
+        image_tensor = self.model.get_tensor_by_name("image_tensor:0")
+        box = self.model.get_tensor_by_name("detection_boxes:0")
+        score = self.model.get_tensor_by_name("detection_scores:0")
+        clss = self.model.get_tensor_by_name("detection_classes:0")
+        num_detections = self.model.get_tensor_by_name("num_detections:0")
+
+        # Actual detection
+        (box, score, clss, num_detections) = self.sess.run(
+            [box, score, clss, num_detections],
+            feed_dict={image_tensor: image_expanded},
+        )
+
+        boxes = box[score > self.confidence_threshold]
+        scores = score[score > self.confidence_threshold]
+
+        return boxes, scores
+
+    def detect_video(
+        self,
+        video,
+        key_frames_only=True,
+    ):
+        """Detects animals in a video
+
+        Args:
+            video (str, Path, or np.ndarray): Path to a video or an array with frames as the first dimension
+            video_name (str, optional): If video is provided as an array and write_boxes_npz is true, must provide a
+                name for the file containing the output bounding boxes
+            key_frames_only (bool): Only load the key frames of the video
+
+        Returns:
+            A list of bounding boxes for each frame and a list of scores for each frame
+        """
+        if isinstance(video, (str, Path)):
+            video = load_video(video, key_frames_only=key_frames_only)
+
+        boxes = []
+        scores = []
+
+        for image in tqdm(video, desc=f"Frames", total=video.shape[0]):
+            image_boxes, image_scores = self.detect_image(image)
+            boxes.append(image_boxes)
+            scores.append(image_scores)
+
+        return boxes, scores
+
+    def compute_features(
+        self,
+        videos,
+        **kwargs,
+    ):
+        """Computes number of detections and total detected area for a list of videos
+
+        Args:
+            videos (list of Path or np.ndarray): A list of video paths or arrays to be processed
+            kwargs (dict): Additional parameters passed to `detect_video`
+
+        Returns:
+            np.ndarray: An array with shape (num videos, 2) where the first column contains the number of detections
+                for each video and the second column contains the total area of detections for each video
+        """
+        if not kwargs.get("key_frames_only", True):
+            raise ValueError("Features only supported for `key_frame_only=True`")
+
+        features = np.empty((len(videos), len(self.FEATURE_NAMES)), dtype=np.int32)
+        for i, video in enumerate(videos):
+            if isinstance(video, (str, Path)):
+                video = load_video(video, key_frames_only=True)
+
+            n_key_frames, height, width = video.shape[:3]
+            boxes, scores = self.detect_video(video, **kwargs)
+            n_detections, area = MegaDetector.compute_n_detections_and_areas(boxes, height, width)
+
+            features[i, 0] = n_key_frames
+            features[i, 1] = height
+            features[i, 2] = width
+            features[i, 3] = n_detections
+            features[i, 4] = area
+
+        return features
+
+    def detect_image_directory(
+        self, directory, extensions=None, recursive=True, key_frames_only=True,
+    ):
+        # setup recursive or not glob string
+        glob_str = "**/*" if recursive else "*"
+
+        # limit extensions if they are passed
+        if isinstance(extensions, str):
+            extensions = [extensions]
+
+        if extensions is not None:
+            extensions = [e.strip(".") for e in extensions]
+            glob_searches = [glob_str + f".{e}" for e in extensions]
+        else:
+            glob_searches = [glob_str]
+
+        # for every kind of file, build up the list of videos
+        img_paths = []
+        for formatted_glob in glob_searches:
+            img_paths += list(Path(directory).glob(formatted_glob))
+
+        # detect on the images
+        output_boxes = {}
+        output_scores = {}
+        for i in img_paths:
+            boxes, scores = self.detect_image(i, key_frames_only=key_frames_only)
+            output_boxes[str(i)], output_scores[str(i)] = boxes, scores
+
+        return output_boxes, output_scores
+
+    def detect_video_directory(
+        self, directory, extensions=None, recursive=True, key_frames_only=True,
+    ):
+        # setup recursive or not glob string
+        glob_str = "**/*" if recursive else "*"
+
+        # limit extensions if they are passed
+        if isinstance(extensions, str):
+            extensions = [extensions]
+
+        if extensions is not None:
+            extensions = [e.strip(".") for e in extensions]
+            glob_searches = [glob_str + f".{e}" for e in extensions]
+        else:
+            glob_searches = [glob_str]
+
+        # for every kind of file, build up the list of videos
+        vid_paths = []
+        for formatted_glob in glob_searches:
+            vid_paths += list(Path(directory).glob(formatted_glob))
+
+        # detect on the videos
+        output_boxes = {}
+        output_scores = {}
+        for v in tqdm(vid_paths, desc="Processing videos"):
+            try:
+                boxes, scores = self.detect_video(v, key_frames_only=key_frames_only)
+                output_boxes[str(v)], output_scores[str(v)] = boxes, scores
+            except Exception as e:
+                self.logger.debug("Error processing %s\n%s", str(v), e)
+                output_boxes[str(v)], output_scores[str(v)] = [np.array([])], [np.array([])]
+
+        return output_boxes, output_scores
+
+    @staticmethod
+    def compute_n_detections_and_areas(boxes, h, w):
+        """Computes the number of detections and total detected area from object detection bounding boxes
+
+        Args:
+            boxes (list of np.ndarray): A list of bounding boxes
+            h (int): Height of the video in pixels
+            w (int): Width of the video in pixels
+
+        Returns:
+            The number of detections and the total detected area
+        """
+        total_area = 0
+        n_detections = 0
+
+        for box in boxes:
+            if len(box) > 0:
+                y1 = int(box[0, 0] * h)
+                x1 = int(box[0, 1] * w)
+                y2 = int(box[0, 2] * h)
+                x2 = int(box[0, 3] * w)
+
+                total_area += (y2 - y1) * (x2 - x1)
+                n_detections += 1
+
+        return n_detections, total_area
+
+    @staticmethod
+    def visualize_video(video, boxes, key_frames_only=True, sleep=0.2):
+        if isinstance(video, (str, Path)):
+            video = load_video(video, key_frames_only=key_frames_only)
+
+        def draw_box(frame, box):
+            try:
+                if len(box):
+                    y1 = int(box[0, 0] * frame.shape[0])
+                    x1 = int(box[0, 1] * frame.shape[1])
+                    y2 = int(box[0, 2] * frame.shape[0])
+                    x2 = int(box[0, 3] * frame.shape[1])
+                    frame = cv2.rectangle(frame, (x1, y1), (x2, y2), (255, 0, 0), 2)
+
+            except Exception as e:
+                print(e)
+
+            finally:
+                return frame
+
+        def callback(frame, ix):
+            f = draw_box(frame, boxes[ix])
+            print(f"frame {ix + 1} / {video.shape[0]}")
+            return f
+
+        viz.display_video(video, frame_cb=callback, sleep=sleep)
+
+    def load_model(self, checkpoint):
+        """
+        Load a detection model (i.e., create a graph) from a .pb file
+        """
+        detection_graph = tf.Graph()
+        with detection_graph.as_default():
+            od_graph_def = tf.GraphDef()
+            with tf.gfile.GFile(checkpoint, "rb") as fid:
+                serialized_graph = fid.read()
+                od_graph_def.ParseFromString(serialized_graph)
+                tf.import_graph_def(od_graph_def, name="")
+
+        return detection_graph
+
+    def _get_model(self, file_name="megadetector_v3.pb", model_url=None):
+        if model_url is None:
+            model_url = self.MODEL_URL
+
+        cache_subdir = "megadetector"
+        model_path = zamba.config.cache_dir / cache_subdir / file_name
+
+        if not model_path.exists():
+            model_path = get_file(
+                fname=file_name,
+                origin=model_url,
+                cache_dir=zamba.config.cache_dir,
+                cache_subdir=cache_subdir,
+                extract=True,
+            )
+
+        return model_path

--- a/zamba/models/mega_detector.py
+++ b/zamba/models/mega_detector.py
@@ -121,7 +121,7 @@ class MegaDetector:
         if not kwargs.get("key_frames_only", True):
             raise ValueError("Features only supported for `key_frame_only=True`")
 
-        features = np.empty((len(videos), len(self.FEATURE_NAMES)), dtype=np.int32)
+        features = []
         for i, video in enumerate(videos):
             if isinstance(video, (str, Path)):
                 video = load_video(video, key_frames_only=True)
@@ -130,11 +130,11 @@ class MegaDetector:
             boxes, scores = self.detect_video(video, **kwargs)
             n_detections, area = MegaDetector.compute_n_detections_and_areas(boxes, height, width)
 
-            features[i, 0] = n_key_frames
-            features[i, 1] = height
-            features[i, 2] = width
-            features[i, 3] = n_detections
-            features[i, 4] = area
+            features.append([
+                n_key_frames, height, width, n_detections, area
+            ])
+
+        features = np.array(features, dtype=np.int32)
 
         return features
 

--- a/zamba/models/mega_detector.py
+++ b/zamba/models/mega_detector.py
@@ -9,7 +9,6 @@ from tqdm import tqdm
 
 import zamba
 from zamba.utils import load_video
-import zamba.visualization as viz
 
 tf.logging.set_verbosity(tf.logging.ERROR)
 
@@ -232,6 +231,8 @@ class MegaDetector:
 
     @staticmethod
     def visualize_video(video, boxes, key_frames_only=True, sleep=0.2):
+        import zamba.visualization as viz
+
         if isinstance(video, (str, Path)):
             video = load_video(video, key_frames_only=key_frames_only)
 

--- a/zamba/models/model.py
+++ b/zamba/models/model.py
@@ -37,7 +37,7 @@ class Model(object):
     def __init__(self, model_path=None, tempdir=None, verbose=False):
         self.model_path = Path(model_path) if model_path is not None else None
         self.delete_tempdir = tempdir is None
-        self.tempdir = Path(tempfile.mkdtemp()) if self.delete_tempdir else Path(tempdir)
+        self.tempdir = Path(tempfile.mkdtemp(prefix="zamba_")) if self.delete_tempdir else Path(tempdir)
         self.verbose = verbose
 
     def __del__(self):
@@ -94,6 +94,18 @@ class Model(object):
         Returns:
 
         """
+        pass
+
+    def load_data(self, data_path):
+        """SampleModel loads pickled data
+
+        Args:
+            data_path:
+
+        Returns:
+
+        """
+        pass
 
 
 class SampleModel(Model):
@@ -171,13 +183,12 @@ class SampleModel(Model):
         """SampleModel loads pickled data
 
         Args:
-            data_path:
+            data_path (pathlib.Path)
 
         Returns:
 
         """
-
-        with open(data_path, 'rb') as f:
+        with data_path.open("rb") as f:
             data = pickle.load(f)
 
         return data

--- a/zamba/tests/test_blanknonblank.py
+++ b/zamba/tests/test_blanknonblank.py
@@ -1,0 +1,14 @@
+import numpy as np
+from zamba.models.blanknonblank import BlankNonBlank
+
+
+def test_blanknonblank(data_dir):
+    n = 10
+
+    bnb = BlankNonBlank()
+    n_features = bnb.model.best_estimator_.n_features_
+
+    X = np.random.rand(n, n_features)
+    blank = bnb.predict_proba(X)[:, 1]
+
+    assert blank.shape == (n,)

--- a/zamba/tests/test_cnnensemble.py
+++ b/zamba/tests/test_cnnensemble.py
@@ -3,9 +3,8 @@ import pytest
 import shutil
 import tempfile
 
-import numpy as np
-
-from zamba.models.cnnensemble.src import config, utils
+from zamba import utils
+from zamba.models.cnnensemble.src import config
 from zamba.models.manager import ModelManager
 
 
@@ -14,7 +13,7 @@ def test_predict_fast(data_dir):
     result = manager.predict(data_dir, save=True)
 
     # check that duiker is most likely class (manually verified)
-    assert np.isclose(result.iloc[0, 21], 0.53087)
+    assert result.idxmax(axis=1).values[0] == "duiker"
 
     result.to_csv(str(config.MODEL_DIR / 'output' / 'test_prediction.csv'))
 
@@ -39,6 +38,16 @@ def test_validate_videos(data_dir):
     paths = data_dir.glob("*")
     valid_videos, invalid_videos = utils.get_valid_videos(paths)
     assert len(invalid_videos) == 0
+
+
+def test_load_data(data_dir):
+    manager = ModelManager(
+        '', model_class='cnnensemble',
+        output_class_names=False,
+        model_kwargs=dict(profile='fast'),
+    )
+    input_paths = manager.model.load_data(data_dir)
+    assert len(input_paths) > 0
 
 
 def test_predict_invalid_videos(data_dir):

--- a/zamba/tests/test_cnnensemble.py
+++ b/zamba/tests/test_cnnensemble.py
@@ -3,11 +3,15 @@ import pytest
 import shutil
 import tempfile
 
-from zamba import utils
+import zamba
 from zamba.models.cnnensemble.src import config
 from zamba.models.manager import ModelManager
 
 
+@pytest.mark.skipif(
+    zamba.config.codeship,
+    reason="Uses too much memory for codeship build, but test locally before merging.",
+)
 def test_predict_fast(data_dir):
     manager = ModelManager('', model_class='cnnensemble', output_class_names=False, model_kwargs=dict(profile='fast'))
     result = manager.predict(data_dir, save=True)
@@ -36,7 +40,7 @@ def test_train():
 def test_validate_videos(data_dir):
     """Tests that all videos in the data directory are marked as valid."""
     paths = data_dir.glob("*")
-    valid_videos, invalid_videos = utils.get_valid_videos(paths)
+    valid_videos, invalid_videos = zamba.utils.get_valid_videos(paths)
     assert len(invalid_videos) == 0
 
 
@@ -50,6 +54,10 @@ def test_load_data(data_dir):
     assert len(input_paths) > 0
 
 
+@pytest.mark.skipif(
+    zamba.config.codeship,
+    reason="Uses too much memory for codeship build, but test locally before merging.",
+)
 def test_predict_invalid_videos(data_dir):
     """Tests whether invalid videos are correctly skipped."""
     tempdir = tempfile.TemporaryDirectory()

--- a/zamba/tests/test_convert_videos.py
+++ b/zamba/tests/test_convert_videos.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import tempfile
+from zamba.convert_videos import convert_videos
+from zamba.utils import get_valid_videos
+
+
+def test_convert_videos(data_dir):
+    input_paths = [path for path in data_dir.glob("*") if not path.stem.startswith(".")]
+    output_directory = tempfile.TemporaryDirectory()
+    output_paths = convert_videos(
+        input_paths, Path(output_directory.name), fps=15, width=448, height=252,
+    )
+
+    valid_videos, invalid_videos = get_valid_videos(output_paths)
+
+    assert len(valid_videos) == len(output_paths)
+    assert len(invalid_videos) == 0
+
+    output_directory.cleanup()

--- a/zamba/tests/test_mega_detector.py
+++ b/zamba/tests/test_mega_detector.py
@@ -1,0 +1,43 @@
+import pytest
+import numpy as np
+
+from zamba.models.mega_detector import MegaDetector
+
+
+@pytest.mark.skip(reason="This test takes hours to run, makes network calls, and is really for local dev only.")
+def test_compute_n_detections_and_areas():
+    # Compare output for test dataset example (af9b5346-1752-49dd-911a-0aeb2329ee98)
+    boxes = [
+        np.array([
+            [0.6169399, 0.6792712, 0.95434475, 0.9707742],
+            [0.5773766, 0.582577, 0.73469436, 0.71894],
+        ]),
+        np.array([
+            [0.6552647, 0.65777284, 0.9466182, 0.8432818],
+            [0.53960234, 0.23661435, 0.7348131, 0.38460845],
+        ]),
+        np.array([
+            [0.47295967, 0.10388512, 0.8461845, 0.18570223],
+        ]),
+        np.array([[]])
+    ]
+    n_detections, area = MegaDetector.compute_n_detections_and_areas(boxes, h=252, w=448)
+    assert n_detections == 3
+    assert area == 20587
+
+    # Parametric example
+    boxes = [
+        np.array(
+            [
+                [0.1, 0.2, 0.3, 0.5],  # area of 600
+                [0.2, 0.2, 0.4, 0.7],  # only first bounding box for a frame is used
+            ],
+        ),
+        np.array([]),
+        np.array(
+            [[0.55, 0.8, 0.6, 0.9]],  # area of 50
+        ),
+    ]
+    n_detections, area = MegaDetector.compute_n_detections_and_areas(boxes, h=100, w=100)
+    assert n_detections == 2
+    assert area == 650

--- a/zamba/tests/test_mega_detector.py
+++ b/zamba/tests/test_mega_detector.py
@@ -1,10 +1,8 @@
-import pytest
 import numpy as np
 
 from zamba.models.mega_detector import MegaDetector
 
 
-@pytest.mark.skip(reason="This test takes hours to run, makes network calls, and is really for local dev only.")
 def test_compute_n_detections_and_areas():
     # Compare output for test dataset example (af9b5346-1752-49dd-911a-0aeb2329ee98)
     boxes = [
@@ -19,7 +17,7 @@ def test_compute_n_detections_and_areas():
         np.array([
             [0.47295967, 0.10388512, 0.8461845, 0.18570223],
         ]),
-        np.array([[]])
+        np.array([])
     ]
     n_detections, area = MegaDetector.compute_n_detections_and_areas(boxes, h=252, w=448)
     assert n_detections == 3

--- a/zamba/tests/test_mega_detector.py
+++ b/zamba/tests/test_mega_detector.py
@@ -5,7 +5,7 @@ from zamba.models.mega_detector import MegaDetector
 
 def test_compute_features(data_dir):
     mega = MegaDetector()
-    video_paths = [path for path in data_dir.glob("*") if not path.startswith(".")]
+    video_paths = [path for path in data_dir.glob("*") if not path.stem.startswith(".")]
     mega_features = mega.compute_features(video_paths)
 
     assert mega_features.shape[1] == len(MegaDetector.FEATURE_NAMES)

--- a/zamba/tests/test_mega_detector.py
+++ b/zamba/tests/test_mega_detector.py
@@ -3,6 +3,14 @@ import numpy as np
 from zamba.models.mega_detector import MegaDetector
 
 
+def test_compute_features(data_dir):
+    mega = MegaDetector()
+    video_paths = [path for path in data_dir.glob("*") if not path.startswith(".")]
+    mega_features = mega.compute_features(video_paths)
+
+    assert mega_features.shape[1] == len(MegaDetector.FEATURE_NAMES)
+
+
 def test_compute_n_detections_and_areas():
     # Compare output for test dataset example (af9b5346-1752-49dd-911a-0aeb2329ee98)
     boxes = [

--- a/zamba/utils.py
+++ b/zamba/utils.py
@@ -1,0 +1,260 @@
+import json
+from math import ceil
+from subprocess import check_output
+
+import cv2
+import av
+import numpy as np
+
+
+def validate_video(path, n_frames=1):
+    """Quickly checks whether a video file is valid by reading the first and last frames
+
+    Args:
+        path (str): Path to a video file
+        n_frames (int): Number of frames to load
+
+    Returns:
+        bool: True if video is valid, False if video is invalid
+    """
+    try:
+        load_video(path, n_frames=1)
+        is_valid = True
+
+    except Exception:
+        is_valid = False
+
+    return is_valid
+
+
+def get_valid_videos(paths):
+    """Splits videos into valid and invalid
+
+    Args:
+        paths (list of str): A list of paths to videos
+
+    Returns:
+        A list of valid video paths and a list of invalid video paths
+    """
+    valid_videos, invalid_videos = [], []
+
+    for path in paths:
+        if validate_video(path):
+            valid_videos.append(path)
+        else:
+            invalid_videos.append(path)
+
+    return valid_videos, invalid_videos
+
+
+def get_video_info(video_path, verbose=False):
+    command = [
+        "ffprobe",
+        "-v",
+        "quiet",
+        "-print_format",
+        "json",
+        "-show_streams",
+        str(video_path),
+    ]
+
+    output_string = check_output(command).decode()
+    info = json.loads(output_string)
+
+    if verbose:
+        print(output_string)
+
+    video_streams = [s for s in info["streams"] if s["codec_type"] == "video"]
+
+    if len(video_streams) > 1:
+        raise ValueError(f"Multiple video streams detected for video {video_path}.")
+
+    stream_data = video_streams[0]
+
+    # frame rate is expressed as a fraction so we divide and round
+    numr, denom = map(int, stream_data["r_frame_rate"].split("/"))
+    fps = ceil(numr / denom)
+    length_s = ceil(float(stream_data["duration"]))
+    return {
+        "fps": fps,
+        "height": stream_data["height"],
+        "width": stream_data["width"],
+        "length_s": length_s,
+        "nb_frames": length_s * fps,
+    }
+
+
+def frame_apply(video, method, *args, inplace=False, **kwargs):
+    """Applies a function to each frame of a video
+
+    Args:
+        video (np.ndarray): An array whose first dimension is the frames of a video. The remaining dimensions can be
+            anything that is comparible with the function being applied
+        method (callable): The function to be called on each frame.
+        inplace (bool): If true, directly update the input video. If false, make a copy. In this case `method` must
+            return frames of the same size and channel depth as the original video
+
+    Returns:
+        An array containing the new video
+
+    """
+    if not inplace:
+        out = np.zeros_like(video)
+    else:
+        out = video
+
+    for i in range(video.shape[0]):
+        out[i, ...] = method(video[i, ...], *args, **kwargs)
+
+    return out
+
+
+def convert_colorspace(array, conversion):
+    """Converts an image of video from one colorspace to another.
+
+    Args:
+        array (np.ndarray): An image with shape (width, height, channels) or video with shape (frames, width, height,
+            channels)
+        conversion (str or int): 'hsv2rgb' 'rgb2hsv' or an integer representing an opencv color conversion, e.g.,
+            cv2.COLOR_RGB2HSV
+
+    Returns:
+        An array of the input image or video converted to a new colorspace.
+    """
+    if conversion.lower() == "hsv2rgb":
+        conversion = cv2.COLOR_HSV2RGB
+    elif conversion.lower() == "rgb2hsv":
+        conversion = cv2.COLOR_RGB2HSV
+    elif not isinstance(conversion, int):
+        raise ValueError(
+            "`conversion` must be 'hsv2rgb', 'rgb2hsv' or an integer representing an opencv color conversion"
+        )
+
+    shape = array.shape
+    output_array = cv2.cvtColor(
+        array.reshape(
+            -1, 1, 3
+        ),  # trick opencv into thinking this is an image with dimensions (h, w, 3)
+        conversion,
+    ).reshape(shape)
+
+    return output_array
+
+
+def load_video(
+    path,
+    h=None,
+    w=None,
+    n_frames=None,
+    key_frames_only=False,
+    open_options=None,
+    grayscale=False,
+):
+    """Loads a video using pyav
+
+    Args:
+        path (str): Path to the video
+        h (int, optional): When to provide?
+        w (int, optional): When to provide?
+        n_frames (int, optional): Number of frames to load, if None load the entire video
+        key_frames_only (bool): Only load the video key frames
+        open_options (dict, optional): Additional arguments passed to `av.open`
+
+    Returns:
+        A numpy array with shape (number of frames, height, width, 3) containing the video
+    """
+    if open_options is None:
+        open_options = dict()
+
+    container = av.open(str(path), options=open_options)
+    container.streams.video[0].thread_type = 'AUTO'  # Go faster!
+
+    if not all([h, w, n_frames]):
+        if h is None:
+            h = container.streams.video[0].height
+
+        if w is None:
+            w = container.streams.video[0].width
+
+        if n_frames is None:
+            n_frames = container.streams.video[0].frames
+
+    if key_frames_only:
+        container.streams.video[0].codec_context.skip_frame = 'NONKEY'
+
+    shape = (n_frames, h, w, 3) if not grayscale else (n_frames, h, w)
+    video_array = np.zeros(shape, dtype=np.uint8)
+
+    i = 0
+    for frame in container.decode(video=0):
+        if grayscale:
+            video_array[i] = np.array(frame.to_image().convert('L'))
+        else:
+            video_array[i] = frame.to_rgb().to_ndarray()
+
+        i += 1
+        if i >= n_frames:
+            break
+
+    return video_array[:i, ...]
+
+
+def unique_processed_path(
+    input_path, directory, file_extension=None, existing_paths=None,
+):
+    """Generates a path that can serve as a destination path after processing an input file.
+
+    One solution is to generate a random destination path, but that can make it difficult to easily tell how raw and
+    processed files are related. Instead, try to use the input file's name as the name of the output file, and if there
+    is a file name collision, add a suffix until the names do not collide.
+
+    Args:
+        input_path (pathlib.Path): The name of the raw file. The output name will have a similar name to this.
+        directory (pathlib.Path): Directory of the destination file path
+        file_extension (str, optional): If none give, the extension of the input path will be used
+        existing_paths (list of pathlib.Path, optional): The destination path will not collide with the file paths in
+            this list
+
+    Returns:
+        pathlib.Path: An output path that does not yet exist and is not in the `existing_paths`
+
+
+    """
+    def is_valid(path):
+        return (not path.exists()) and (path not in existing_paths)
+
+    if file_extension is None:
+        file_extension = input_path.suffix
+
+    if existing_paths is None:
+        existing_paths = []
+
+    output_path = directory / input_path.with_suffix(file_extension).name
+    stem = output_path.stem
+    unique_suffix = 0
+
+    while not is_valid(output_path):
+        output_path = output_path.with_name(f"{stem}_{unique_suffix}{file_extension}")
+        unique_suffix += 1
+
+    return output_path
+
+
+def unique_processed_paths(
+    input_paths, directory, file_extension=None, existing_paths=None,
+):
+    if existing_paths is None:
+        existing_paths = []
+
+    output_paths = []
+    for input_path in input_paths:
+        output_path = unique_processed_path(
+            input_path,
+            directory,
+            file_extension=file_extension,
+            existing_paths=existing_paths + output_paths,
+        )
+
+        output_paths.append(output_path)
+
+    return output_paths

--- a/zamba/utils.py
+++ b/zamba/utils.py
@@ -18,7 +18,7 @@ def validate_video(path, n_frames=1):
         bool: True if video is valid, False if video is invalid
     """
     try:
-        load_video(path, n_frames=1)
+        load_video(path, n_frames=n_frames)
         is_valid = True
 
     except Exception:

--- a/zamba/visualization.py
+++ b/zamba/visualization.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import time
+
+import cv2
+from io import BytesIO
+from IPython.display import display, Image, clear_output
+import numpy as np
+import PIL.Image
+
+
+def display_array(array, fmt="png"):
+    """Displays a numpy array as an image in a Jupyter notebook"""
+    array = np.uint8(array)
+    byte = BytesIO()
+
+    if len(array.shape) == 2:
+        mode = 'L'
+    else:
+        mode = 'RGB'
+
+    PIL.Image.fromarray(array, mode=mode).save(byte, fmt)
+    display(Image(data=byte.getvalue()))
+
+
+def display_video(vid, frame_cb=None, sleep=None, frame_rate=None):
+    ''' Renders videos as frame-by-frame images in notebook; frame_cb
+        is optional callback to do additional work with the frame and the index.
+
+        vid can be a string or path, in which case it is read from the file
+        vid can also be a numpy array, in which case it is looped over
+    '''
+    if isinstance(vid, (str, Path)):
+        vid = cv2.VideoCapture(vid)
+
+    def _get_next_frame(vid, ix):
+        if isinstance(vid, cv2.VideoCapture):
+            ret, frame = vid.read()
+
+            if not ret:
+                vid.release()
+                return ret, frame
+
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            return ret, frame
+        else:
+            if ix >= vid.shape[0]:
+                return False, None
+            else:
+                return True, vid[ix, ...]
+
+    i = 0
+    try:
+        while True:
+            ret, frame = _get_next_frame(vid, i)
+
+            if not ret:
+                break
+
+            if frame_cb:
+                frame = frame_cb(frame, i)
+
+            display_array(frame, fmt='jpeg')
+            clear_output(wait=True)
+
+            if frame_rate:
+                time.sleep(1 / frame_rate)
+
+            if sleep:
+                time.sleep(sleep)
+
+            i += 1
+
+    except KeyboardInterrupt:
+        if isinstance(vid, cv2.VideoCapture):
+            vid.release()


### PR DESCRIPTION
Incorporate the changes from [zamba-background-detection](https://github.com/drivendataorg/zamba-background-detection) into the main zamba package.

Major changes:
 - `zamba/convert_videos.py`: resample videos prior to processing
 - `zamba/models/mega_detector.py`: Mega object recognition that draws bounding boxes around objects in frames of a movie. Also includes code to extract features from this: number of key frames, number of detections, bounding box area
 - `zamba/models/blanknonblank.py`: The winning model from prototyping -- use the "zamba" features combined with those derived from the Mega object recognition algorithm.
 - `zamba/models/cnnensemble_model.py`: Incorporates the new blank/non-blank model to populate the "blank" probability for each video

Minor changes:
 - Instead of caching files within the package directory, use `appdirs` to get a OS-specific cache directory when `ZAMBA_CACHE_DIR` not specified
 - For the new code, use the optimized `av` based video loader. (Competition code uses the old code for now).
 - Upgraded sklearn. The zamba competition pretrained model used sklearn 0.19.1 and the new pretrained blank/non-blank model used 0.21.2. The new model will not run on 0.19.1, and the old model raises warnings about loading a pickled LabelEncoder that was generated by an older version.