### PR TITLE
Optional resampling and blank/non-blank; updated error handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
+        pip install Cython==0.28.1 --install-option="--no-cython-compile"
         make reqs
 
     - name: Lint Package

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 # requirements for local OSX development
 # requires `brew install gcc`
 reqs:
-	python -m pip install -U pip Cython
+	python -m pip install -U pip
 	python -m pip install -r requirements-dev.txt
 	python -m pip install -e .[cpu]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flake8==3.5.0
 h5py==2.10.0
 joblib==0.13.2
 matplotlib==3.3.0
-numpy==1.19.1
+numpy==1.18.5
 pandas==1.1.0
 protobuf==3.6.1
 scikit-learn==0.21.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ long_description = open(project_path / 'README.md').read()
 
 setup(
     name='zamba',
-    version='0.1.7',
+    version='0.1.8',
     description='Zamba is a tool to identify the species seen in camera trap videos from sites in central Africa.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -51,6 +51,14 @@ def main():
               is_flag=True,
               default=False,
               help="Displays additional logging information during processing.")
+@click.option('--resample',
+              is_flag=True,
+              default=False,
+              help="Resamples videos to a consistent size and framerate (fps=15, width=448, height=252).")
+@click.option('--separate_blank',
+              is_flag=True,
+              default=False,
+              help="Does a second stage blank/non-blank that is more accurate; recommended with resample.")
 def predict(data_path,
             pred_path,
             tempdir,
@@ -58,7 +66,9 @@ def predict(data_path,
             output_class_names,
             model_profile,
             weight_download_region,
-            verbose):
+            verbose,
+            resample,
+            separate_blank):
     """Identify species in a video.
 
       This is a command line interface for prediction on camera trap footage. Given a path to camera trap footage,
@@ -80,7 +90,10 @@ def predict(data_path,
                                              download_region=weight_download_region))
 
     # Make predictions, return a DataFrame
-    manager.predict(data_path, pred_path=pred_path, save=True)
+    manager.predict(data_path, pred_path=pred_path, save=True, predict_kwargs=dict(
+        resample=resample,
+        seperate_blank_model=separate_blank,
+    ))
 
 
 @main.command()

--- a/zamba/tests/test_cli.py
+++ b/zamba/tests/test_cli.py
@@ -6,7 +6,7 @@ from zamba.cli import predict
 
 def test_predict_modelpath(sample_model_path, sample_data_path, mocker):  # noqa: F811
     # mock predictions to just test CLI args
-    def pred_mock(self, data_path, pred_path='', save=False):
+    def pred_mock(self, data_path, pred_path='', save=False, predict_kwargs=None):
         return None
 
     mocker.patch('zamba.cli.ModelManager.predict', pred_mock)


### PR DESCRIPTION
## Description

Added a few parameters that significantly reduce the computation that we do by default. 

 - Adds a `--resample` flag to indicate if we should re-encode the videos to a consistent size and frame rate (default `False`).
 - Adds a `--separate_blank` flag to skip the additional blank/non-blank model that does object detection so is computationally intensive (default `False`)

We also used to try to pre-load a few frames from a video to see if it was valid. Turns out that videos can still fail to load downstream even if we are able to load the first frames. Now we catch invalid videos deeper in the algorithm code and then bookkeep those all the way back up to each ensemble member.

