### PR TITLE
data_path can be directory or csv with filepaths

### DIFF
--- a/zamba/models/cnnensemble_model.py
+++ b/zamba/models/cnnensemble_model.py
@@ -50,10 +50,16 @@ class CnnEnsemble(Model):
             self._download_weights_if_needed(download_region)
 
     def load_data(self, data_path):
-        input_paths = [
-            path for path in data_path.glob('**/*')
-            if not path.is_dir() and not path.name.startswith(".")
-        ]
+
+        if Path(data_path).is_dir():
+            input_paths = [
+                path for path in data_path.glob('**/*')
+                if not path.is_dir() and not path.name.startswith(".")
+            ]
+
+        elif Path(data_path).suffix == '.csv':
+            df = pd.read_csv(data_path)
+            input_paths = [Path(f) for f in df.filepath.values]
 
         return input_paths
 

--- a/zamba/models/cnnensemble_model.py
+++ b/zamba/models/cnnensemble_model.py
@@ -64,7 +64,7 @@ class CnnEnsemble(Model):
 
             df = pd.read_csv(data_path, header=(None if no_header else 0))
             # assume first column unless otherwise specified
-            filepath_col = df.columns[0] if filepath_col is None
+            filepath_col = df.columns[0] if filepath_col is None else filepath_col
             input_paths = [Path(f) for f in df[filepath_col].values]
 
         return input_paths

--- a/zamba/models/cnnensemble_model.py
+++ b/zamba/models/cnnensemble_model.py
@@ -49,17 +49,23 @@ class CnnEnsemble(Model):
         if download_weights:
             self._download_weights_if_needed(download_region)
 
-    def load_data(self, data_path):
-
-        if Path(data_path).is_dir():
+    def load_data(self, data_path, filepath_col=None):
+        if data_path.is_dir():
             input_paths = [
                 path for path in data_path.glob('**/*')
                 if not path.is_dir() and not path.name.startswith(".")
             ]
 
         elif Path(data_path).suffix == '.csv':
-            df = pd.read_csv(data_path)
-            input_paths = [Path(f) for f in df.filepath.values]
+            # check for header-less list of files
+            with data_path.open("r") as f:
+                l1 = f.readline()
+                no_header = Path(l1.split(",")[0]).exists()
+
+            df = pd.read_csv(data_path, header=(None if no_header else 0))
+            # assume first column unless otherwise specified
+            filepath_col = df.columns[0] if filepath_col is None
+            input_paths = [Path(f) for f in df[filepath_col].values]
 
         return input_paths
 


### PR DESCRIPTION
## Description
Adds support for data_path pointing to a csv with a column containing filepaths that contains the videos to predict upon.

This is still WIP and is missing:
- [ ] updated documentation
- [ ] tests


## Tests
*Due to the long run times and large memory requirements, some tests cannot be completed on our CI platform. Those tests should be marked with `@pytest.skipif(zamba.config.codetree)` decorator. Run the tests locally using `pytest zamba` and paste the output below.*