### PR TITLE
Check if file exists for valid videos

### DIFF
--- a/zamba/models/cnnensemble_model.py
+++ b/zamba/models/cnnensemble_model.py
@@ -94,7 +94,9 @@ class CnnEnsemble(Model):
                 classes
         """
         processed_paths = self.preprocess_videos(file_names, resample=resample)
-        valid_videos = list(processed_paths.values())
+
+        # exclude videos where output path doesn't exist (e.g. videos that can't be resampled)
+        valid_videos = [v for v in processed_paths.values() if v.exists()]
         invalid_videos = []
 
         l1_results = {}

--- a/zamba/models/cnnensemble_model.py
+++ b/zamba/models/cnnensemble_model.py
@@ -97,7 +97,7 @@ class CnnEnsemble(Model):
 
         # exclude videos where output path doesn't exist (e.g. videos that can't be resampled)
         valid_videos = [v for v in processed_paths.values() if v.exists()]
-        invalid_videos = []
+        invalid_videos = [v for v in processed_paths.values() if v not in valid_videos]
 
         l1_results = {}
         invalid_mask = np.zeros(len(valid_videos), dtype=bool)


### PR DESCRIPTION
## Description

Fix failing local tests by checking that file paths exist for `valid_videos`. For resampling, we generate the output paths first but if a file can't be resampled, the path will exist in name only (no file). 

## Tests
*Due to the long run times and large memory requirements, some tests cannot be completed on our CI platform. Those tests should be marked with `@pytest.skipif(zamba.config.codeship)` decorator. Run the tests locally using `pytest zamba` and paste the output below.*
```
13:33 $ make test
python -m pytest -s zamba
======================================== test session starts ========================================
platform linux -- Python 3.6.13, pytest-5.4.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/emily/zamba
plugins: cov-2.10.0, mock-3.1.1
collected 13 items

zamba/tests/test_blanknonblank.py .
zamba/tests/test_cli.py .
Resampling videos: 100%|███████████████████████████████████████████████| 1/1 [00:02<00:00,  2.13s/it]
Predicting on 1 L1 models: 100%|███████████████████████████████████████| 1/1 [00:37<00:00, 37.82s/it]
Frames: 100%|██████████████████████████████████████████████████████████| 1/1 [00:14<00:00, 14.60s/it]
Resampling videos: 100%|███████████████████████████████████████████████| 4/4 [00:05<00:00,  1.41s/it]
Predicting on 1 L1 models: 100%|███████████████████████████████████████| 1/1 [00:49<00:00, 49.43s/it]
Frames: 100%|██████████████████████████████████████████████████████████| 1/1 [00:14<00:00, 14.70s/it]
Frames: 100%|██████████████████████████████████████████████████████████| 1/1 [00:07<00:00,  7.58s/it]
.
Resampling videos: 100%|███████████████████████████████████████████████| 1/1 [00:02<00:00,  2.48s/it]
.
Frames: 100%|██████████████████████████████████████████████████████████| 2/2 [00:22<00:00, 11.34s/it]
..
zamba/tests/test_sample_model.py ..

========================================= warnings summary ==========================================
zamba/tests/test_cnnensemble.py: 681 tests with warnings
  /home/emily/miniconda3/envs/zamba/lib/python3.6/site-packages/skvideo/io/ffmpeg.py:270: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    arr = np.fromstring(self._proc.stdout.read(framesize), dtype=np.uint8)

zamba/tests/test_cnnensemble.py: 681 tests with warnings
  /home/emily/miniconda3/envs/zamba/lib/python3.6/site-packages/skvideo/io/ffmpeg.py:282: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    result = np.fromstring(s, dtype='uint8')

zamba/tests/test_cnnensemble.py::test_predict_fast
zamba/tests/test_cnnensemble.py::test_predict_invalid_videos
  /home/emily/miniconda3/envs/zamba/lib/python3.6/site-packages/sklearn/base.py:306: UserWarning: Trying to unpickle estimator LabelEncoder from version 0.19.1 when using version 0.21.2. This might lead to breaking code or invalid results. Use at your own risk.
    UserWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```
