### PR TITLE
Update megadetector to version 4.1

### DIFF
--- a/zamba/models/mega_detector.py
+++ b/zamba/models/mega_detector.py
@@ -17,7 +17,8 @@ class MegaDetector:
     """ Instantiate and detect on images or videos using AI for Earth's MegaDetector.
 
         Read more documentation at https://github.com/microsoft/CameraTraps/blob/master/megadetector.md and download
-        the weights from "https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/md_v4.1.0/md_v4.1.0.pb"
+        the weights from:
+        https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/md_v4.1.0/md_v4.1.0.pb
 
         Attributes:
             model (tensorflow.framework.ops.Graph)
@@ -34,9 +35,9 @@ class MegaDetector:
     ):
         """
             Args:
-                model_path (str, optional): Path to mega detector weights (downloaded from
-                    "https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/md_v4.1.0/md_v4.1.0.pb"). If
-                    omitted, the weights will be downloaded automatically
+                model_path (str, optional): Path to mega detector weights. Default: downloaded from
+                https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/md_v4.1.0/md_v4.1.0.pb
+
                 confidence_threshold (float): Only keep bounding boxes with scores above this threshold
         """
         if model_path is None:

--- a/zamba/models/mega_detector.py
+++ b/zamba/models/mega_detector.py
@@ -17,14 +17,14 @@ class MegaDetector:
     """ Instantiate and detect on images or videos using AI for Earth's MegaDetector.
 
         Read more documentation at https://github.com/microsoft/CameraTraps/blob/master/megadetector.md and download
-        the weights from https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/megadetector_v3.pb
+        the weights from "https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/md_v4.1.0/md_v4.1.0.pb"
 
         Attributes:
             model (tensorflow.framework.ops.Graph)
             sess (tensorflow.client.session.Session)
             confidence_threshold (float): Only keep bounding boxes with scores above this threshold
     """
-    MODEL_URL = "https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/megadetector_v3.pb"
+    MODEL_URL = "https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/md_v4.1.0/md_v4.1.0.pb"
     FEATURE_NAMES = ["n_key_frames", "h", "w", "n_detections", "total_area"]
 
     def __init__(
@@ -35,7 +35,7 @@ class MegaDetector:
         """
             Args:
                 model_path (str, optional): Path to mega detector weights (downloaded from
-                    https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/megadetector_v3.pb). If
+                    "https://lilablobssc.blob.core.windows.net/models/camera_traps/megadetector/md_v4.1.0/md_v4.1.0.pb"). If
                     omitted, the weights will be downloaded automatically
                 confidence_threshold (float): Only keep bounding boxes with scores above this threshold
         """
@@ -272,9 +272,11 @@ class MegaDetector:
 
         return detection_graph
 
-    def _get_model(self, file_name="megadetector_v3.pb", model_url=None):
+    def _get_model(self, model_url=None):
         if model_url is None:
             model_url = self.MODEL_URL
+
+        file_name = model_url.rsplit("/", 1)[-1]
 
         cache_subdir = "megadetector"
         model_path = zamba.config.cache_dir / cache_subdir / file_name


### PR DESCRIPTION
## Description

Updates default megadetector version to 4.1 instead of v3.


## Tests
```
(zamba) ubuntu@ip-172-31-9-197:~/zamba$ make test
python -m pytest -s zamba
============================================================================================================================================================== test session starts ===============================================================================================================================================================
platform linux -- Python 3.6.13, pytest-5.4.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/ubuntu/zamba
plugins: cov-2.10.0, mock-3.1.1
collected 13 items                                                                                                                                                                                                                                                                                                                               

zamba/tests/test_blanknonblank.py Downloading data from https://drivendata-public-assets.s3.amazonaws.com/zamba-and-obj-rec-0.859.joblib
8126464/8122742 [==============================] - 1s 0us/step
.
zamba/tests/test_cli.py .
Resampling videos: 100%|███████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.28s/it]
Predicting on 1 L1 models: 100%|███████████████████████████████████████████████████████████████████████████████| 1/1 [00:40<00:00, 40.25s/it]
Frames: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:13<00:00, 13.02s/it]
Resampling videos: 100%|███████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:05<00:00,  1.32s/it]
Predicting on 1 L1 models: 100%|███████████████████████████████████████████████████████████████████████████████| 1/1 [00:50<00:00, 50.39s/it]
Frames: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:14<00:00, 14.68s/it]
Frames: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:06<00:00,  6.59s/it]
.
Resampling videos: 100%|███████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.57s/it]
.
Frames: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:20<00:00, 10.17s/it]
..
zamba/tests/test_sample_model.py ..

============================================================= warnings summary ==============================================================
zamba/tests/test_cnnensemble.py: 681 tests with warnings
  /home/ubuntu/anaconda3/envs/zamba/lib/python3.6/site-packages/skvideo/io/ffmpeg.py:270: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    arr = np.fromstring(self._proc.stdout.read(framesize), dtype=np.uint8)

zamba/tests/test_cnnensemble.py: 681 tests with warnings
  /home/ubuntu/anaconda3/envs/zamba/lib/python3.6/site-packages/skvideo/io/ffmpeg.py:282: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    result = np.fromstring(s, dtype='uint8')

zamba/tests/test_cnnensemble.py::test_predict_fast
zamba/tests/test_cnnensemble.py::test_predict_invalid_videos
  /home/ubuntu/anaconda3/envs/zamba/lib/python3.6/site-packages/sklearn/base.py:306: UserWarning: Trying to unpickle estimator LabelEncoder from version 0.19.1 when using version 0.21.2. This might lead to breaking code or invalid results. Use at your own risk.
    UserWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================= 11 passed, 2 skipped, 1364 warnings in 204.17s (0:03:24) ==========================================
```
