### PR TITLE
Skip on failure, actually drop duplicates, clarify logging

### DIFF
--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -404,7 +404,7 @@ class TrainConfig(ZambaBaseModel):
         validate_model_name_and_checkpoint
     )
 
-    @validator("scheduler_config", always=True, skip_on_failure=True)
+    @validator("scheduler_config", always=True)
     def validate_scheduler_config(cls, scheduler_config):
         if scheduler_config is None:
             return SchedulerConfig(scheduler=None)

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -176,7 +176,7 @@ def validate_model_name_and_checkpoint(cls, values):
     if checkpoint is None and model_name is None:
         raise ValueError("Must provide either model_name or checkpoint path.")
 
-    # checkpoint always supercedes model since model_name cannot be None
+    # checkpoint always supercedes model
     elif checkpoint is not None and model_name is not None:
         logger.info(f"Using checkpoint file: {checkpoint}.")
 


### PR DESCRIPTION
Assortment of fixes:
- need skip_on_failure on all root validators in order to get helpful validation error and not move to the next validator which will  give us a cryptic "values[...]" is None
- actually drop duplicate filepaths so we only get one row our per prediction. currently we just say we do this but it's not implemented
- model_name has a default so if you just pass a checkpoint, model_name will be specified. we don't need to remind users of this all the time and can just tell them we're using the checkpoint