### PR TITLE
Support training models with just two classes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import random
+import string
 from typing import Optional, Union
 
 from loguru import logger
@@ -76,6 +77,21 @@ class DummyTrainConfig(TrainConfig):
 @pytest.fixture(scope="session")
 def labels_relative_path() -> os.PathLike:
     return ASSETS_DIR / "labels.csv"
+
+
+def labels_n_classes_df(n_classes):
+    """Get up a labels data frame where the labels are up to
+    26 classes.
+    """
+    if n_classes > len(string.ascii_uppercase):
+        raise ValueError("n_classes must be less than 26")
+
+    choices = string.ascii_uppercase[:n_classes]
+
+    df = pd.read_csv(ASSETS_DIR / "labels.csv")
+    df.label = random.choices(choices, k=len(df))
+
+    return df
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def labels_relative_path() -> os.PathLike:
 
 
 def labels_n_classes_df(n_classes):
-    """Get up a labels data frame where the labels are up to
+    """Get up a labels dataframe where the labels are up to
     26 classes.
     """
     if n_classes > len(string.ascii_uppercase):


### PR DESCRIPTION
Top K accuracy fails to calculate if the number of classes is 2 or fewer. In that case, we just calculate accuracy instead.