### PR TITLE
Write out splits + fix for videos that cannot be loaded

### DIFF
--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -513,6 +513,13 @@ class TrainConfig(ZambaBaseModel):
                     k=len(labels),
                 )
 
+                logger.info(
+                    f"Writing out split information to {values['save_directory'] / 'splits.csv'}."
+                )
+                labels.reset_index()[["filepath", "split"]].drop_duplicates().to_csv(
+                    values["save_directory"] / "splits.csv", index=False
+                )
+
         # filepath becomes column instead of index
         values["labels"] = labels.reset_index()
         return values


### PR DESCRIPTION
If you're finetuning and having splits autogenerated, you're going to want to know which files were used for training vs. holdout, particularly so you can run your trained model on the holdout/test set. 

Changes:
- writes out filepath and split column to csv in save_dir / splits.csv
- incorporates fix for videos that cannot be loaded (warn and write all zeros)

Before merge:
- [ ] add test for splits files getting written out
- [ ] add test for bad video getting zeroes