### PR TITLE
[V2] Clean up dev dependencies

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -20,10 +20,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -r requirements-dev/docs.txt
+
       - name: Build documentation
         run: |
           make docs
+
       - name: Deploy site preview to Netlify
         uses: nwtgck/actions-netlify@v1.1
         with:

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -r requirements-dev/docs.txt
 
       - name: Build documentation
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
-          pip install -e .[dev]
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev/lint.txt
 
       - name: Lint package
         run: |
@@ -61,8 +61,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
-          pip install -e  .[dev]
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements-dev.txt
 
       - name: Run tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifeq (${CPU_OR_GPU}, gpu)
 	conda install cudatoolkit=11.0.3 cudnn=8.0 -c conda-forge
 endif
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
-	$(PYTHON_INTERPRETER) -m pip install -e .[dev]
+	$(PYTHON_INTERPRETER) -m pip install -r requirements-dev.txt
 
 
 ## Delete all compiled Python files

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mkdocs>=1.1
-mkdocs-jupyter
-mkdocs-material>=7
-mkdocstrings>=0.15
+-e .[tests]
+
+-r requirements-dev/docs.txt
+-r requirements-dev/lint.txt

--- a/requirements-dev/docs.txt
+++ b/requirements-dev/docs.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.1
+mkdocs-material>=7
+mkdocstrings>=0.15

--- a/requirements-dev/lint.txt
+++ b/requirements-dev/lint.txt
@@ -1,0 +1,2 @@
+black
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,13 +68,8 @@ console_scripts =
     zamba = zamba.cli:app
 
 [options.extras_require]
-dev =
-    black
+tests =
     coverage
-    flake8
-    mkdocs
-    mkdocs-material
-    mkdocstrings
     pytest
     pytest-coverage
     pytest-mock


### PR DESCRIPTION
- Remove dev dependencies that don't appear to be used anywhere. 
- Split out some dev dependencies into separate requirements files. The way to now install everything is `pip install -r requirements-dev.txt`. 
  - `requirements-dev/docs.txt`: this single-sources what was previously duplicated in `requirements-dev.txt` for building docs
  - `requirements-dev/lint.txt`: this speeds up code quality installation from ~3 min to ~8 sec