### PR TITLE
Fix docs-build

### DIFF
--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev/docs.txt
+          pip install -e .
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
`mkdocstrings` needs zamba to be installed. We only had zamba installed in docs-preview: https://github.com/drivendataorg/zamba/blob/eedaccde869f964dd5fc98f3a09f5e637a8f04ca/.github/workflows/docs-preview.yml#L23