### PR TITLE
Change default backbone finetuning, auto_lr_find, and fix persistent workers bug

### DIFF
--- a/templates/european.yaml
+++ b/templates/european.yaml
@@ -7,7 +7,7 @@ train_config:
     multiplier: 1
     pre_train_bn: false
     train_bn: false
-    unfreeze_backbone_at_epoch: 5
+    unfreeze_backbone_at_epoch: 15
     verbose: true
 
 video_loader_config:

--- a/templates/slowfast.yaml
+++ b/templates/slowfast.yaml
@@ -4,10 +4,10 @@ train_config:
   model_name: slowfast
   backbone_finetune_config:
     backbone_initial_ratio_lr: 0.01
-    multiplier: 1
+    multiplier: 10
     pre_train_bn: false
     train_bn: false
-    unfreeze_backbone_at_epoch: 5
+    unfreeze_backbone_at_epoch: 3
     verbose: true
   early_stopping_config:
     patience: 5

--- a/templates/time_distributed.yaml
+++ b/templates/time_distributed.yaml
@@ -7,7 +7,7 @@ train_config:
     multiplier: 1
     pre_train_bn: True
     train_bn: False
-    unfreeze_backbone_at_epoch: 5
+    unfreeze_backbone_at_epoch: 3
     verbose: True
   early_stopping_config:
     patience: 5


### PR DESCRIPTION
Addresses a few issues:
- Changes the early stopping default patience from 3 to 5
- Changes the backbone finetuning default unfreeze at from 15 to 5.
- Changes the default setting for `auto_lr_find` from `True` to `False`.
- Fixes a bug where `num_workers=0` and `persistent_workers=True` values conflict.
