### PR TITLE
Add torch to build requirements in make requirements recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ requirements:
 ifeq (${CPU_OR_GPU}, gpu)
 	conda install cudatoolkit=11.0.3 cudnn=8.0 -c conda-forge
 endif
-	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
+	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel torch
 	$(PYTHON_INTERPRETER) -m pip install -r requirements-dev.txt
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts


### PR DESCRIPTION
Closes #165 

Simple fix for the missing build requirement.