### PR TITLE
Ensure videos are allocated into all specified splits

### DIFF
--- a/tests/assets/labels.csv
+++ b/tests/assets/labels.csv
@@ -1,5 +1,5 @@
 filepath,label,split
-data/raw/savanna/Grumeti_Tanzania/K38_check3/09190048_Hyena.AVI,gorilla,train
+data/raw/savanna/Grumeti_Tanzania/K38_check3/09190048_Hyena.AVI,antelope_duiker,train
 data/raw/savanna/Grumeti_Tanzania/G41_check2/09100029_Eland.MP4,antelope_duiker,train
 data/raw/savanna/Gorongosa_Mozambique/2017 Videos/F13_Cam027/Baboon/07120049.AVI,elephant,train
 data/raw/goualougo_2013/chimp_MPI_FID_2013/MPI_FID_31_Abel/06-May-2013/FID_31_Abel_2013-5-6_0027.AVI,gorilla,train
@@ -15,6 +15,6 @@ data/raw/chimpandsee/Kay_H12/Kay_vid2_0803042_1459433_20130528/PICT0265.AVI,gori
 data/raw/chimpandsee/Kor_C5/Kor_vid6_0485466_0567428_20141120/EK000019.AVI,gorilla,val
 data/raw/chimpandsee/Trip_5/card 1.2_location/PICT0074.ASF,gorilla,val
 data/raw/chimpandsee/Sap_D1/Sap_vid24_0524356_0589414_20110915/PICT0021.ASF,gorilla,holdout
-data/raw/chimpandsee/Bwi_A3/bwi_vid7_806110_9885227_20120911/PICT0146.AVI,gorilla,holdout
+data/raw/chimpandsee/Bwi_A3/bwi_vid7_806110_9885227_20120911/PICT0146.AVI,elephant,holdout
 data/raw/chimpandsee/Gas_D4/Gas_Vid20_0786029_0808836_20130725/EK000018.AVI,elephant,holdout
 data/raw/salonga/MISSION_3/Team_Pedro/Trans_322__Cam_1_488454_9765353_Date_24-11-2017/01110103.AVI,antelope_duiker,holdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,11 @@ MODEL_MAPPING["DummyZambaVideoClassificationLightningModule"] = {
 class DummyTrainConfig(TrainConfig):
     # let model name be "dummy" without causing errors
     model_name: str
+    batch_size = 1
+    max_epochs = 1
+    model_name = "dummy"
+    skip_load_validation = True
+    auto_lr_find = False
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -203,8 +203,16 @@ def test_labels_with_invalid_split(labels_absolute_path):
 
 
 def test_labels_no_splits(labels_no_splits, tmp_path):
-    config = TrainConfig(data_dir=TEST_VIDEOS_DIR, labels=labels_no_splits, save_dir=tmp_path)
-    assert set(config.labels.split.unique()) == set(("holdout", "train", "val"))
+    labels_three_videos = pd.read_csv(labels_no_splits).head(3)
+    # test with fewer videos and ensure we still get one of each
+    config = TrainConfig(
+        data_dir=TEST_VIDEOS_DIR,
+        labels=labels_three_videos,
+        save_dir=tmp_path,
+        split_proportions=dict(train=3, val=1, holdout=1)
+        )
+
+    assert set(pd.read_csv(tmp_path / "splits.csv").split.unique()) == set(["train", "val", "holdout"])
 
 
 def test_labels_split_proportions(labels_no_splits, tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,14 +205,16 @@ def test_labels_with_invalid_split(labels_absolute_path):
 def test_labels_no_splits(labels_no_splits, tmp_path):
     labels_three_videos = pd.read_csv(labels_no_splits).head(3)
     # test with fewer videos and ensure we still get one of each
-    config = TrainConfig(
+    _ = TrainConfig(
         data_dir=TEST_VIDEOS_DIR,
         labels=labels_three_videos,
         save_dir=tmp_path,
-        split_proportions=dict(train=3, val=1, holdout=1)
-        )
+        split_proportions=dict(train=3, val=1, holdout=1),
+    )
 
-    assert set(pd.read_csv(tmp_path / "splits.csv").split.unique()) == set(["train", "val", "holdout"])
+    assert set(pd.read_csv(tmp_path / "splits.csv").split.unique()) == set(
+        ["train", "val", "holdout"]
+    )
 
 
 def test_labels_split_proportions(labels_no_splits, tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -224,7 +224,7 @@ def test_labels_split_proportions(labels_no_splits, tmp_path):
         split_proportions={"a": 3, "b": 1},
         save_dir=tmp_path,
     )
-    assert config.labels.split.value_counts().to_dict() == {"a": 14, "b": 5}
+    assert config.labels.split.value_counts().to_dict() == {"a": 13, "b": 6}
 
 
 def test_from_scratch(labels_absolute_path):

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -17,6 +17,20 @@ def test_model_manager(dummy_trainer):
     assert not (dummy_trainer.model.model[3].weight == 0).all()
 
 
+def test_no_early_stopping(
+    labels_absolute_path, tmp_path, dummy_checkpoint, dummy_video_loader_config
+):
+    config = DummyTrainConfig(
+        labels=labels_absolute_path,
+        data_dir=TEST_VIDEOS_DIR,
+        checkpoint=dummy_checkpoint,
+        early_stopping_config=None,
+        save_dir=tmp_path / "my_model",
+        num_workers=1,
+    )
+    train_model(train_config=config, video_loader_config=dummy_video_loader_config)
+
+
 def test_save_checkpoint(dummy_trained_model_checkpoint):
     checkpoint = torch.load(dummy_trained_model_checkpoint)
 
@@ -76,14 +90,9 @@ def test_save_metrics_less_than_two_classes(
         train_config=DummyTrainConfig(
             labels=labels,
             data_dir=TEST_VIDEOS_DIR,
-            model_name="dummy",
             checkpoint=dummy_checkpoint,
-            max_epochs=1,
-            batch_size=1,
-            auto_lr_find=False,
             num_workers=2,
             save_dir=tmp_path / "my_model",
-            skip_load_validation=True,
         ),
         video_loader_config=dummy_video_loader_config,
     )
@@ -136,14 +145,9 @@ def test_train_save_dir_overwrite(
     config = DummyTrainConfig(
         labels=labels_absolute_path,
         data_dir=TEST_VIDEOS_DIR,
-        model_name="dummy",
         checkpoint=dummy_checkpoint,
         save_dir=tmp_path / "my_model",
-        skip_load_validation=True,
         overwrite=True,
-        max_epochs=1,
-        batch_size=1,
-        auto_lr_find=False,
         num_workers=1,
     )
 

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -501,11 +501,11 @@ class TrainConfig(ZambaBaseModel):
                     "No 'site' column found so videos will be randomly allocated using split proportions."
                 )
 
-                expected_labels = [k for k, v in values["split_proportions"].items() if v > 0]
+                expected_splits = [k for k, v in values["split_proportions"].items() if v > 0]
                 labels["split"] = ""
                 seed = SPLIT_SEED
 
-                while len(np.setdiff1d(expected_labels, labels.split.unique())):
+                while len(np.setdiff1d(expected_splits, labels.split.unique())):
 
                     random.seed(seed)
                     labels["split"] = random.choices(

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -245,8 +245,12 @@ def train_model(
     model_checkpoint = ModelCheckpoint(
         dirpath=logging_and_save_dir,
         filename=train_config.model_name,
-        monitor=train_config.early_stopping_config.monitor,
-        mode=train_config.early_stopping_config.mode,
+        monitor=train_config.early_stopping_config.monitor
+        if train_config.early_stopping_config is not None
+        else None,
+        mode=train_config.early_stopping_config.mode
+        if train_config.early_stopping_config is not None
+        else "min",
     )
 
     callbacks = [model_checkpoint]


### PR DESCRIPTION
This PR fixes the issue that caused the following error:

```
RuntimeError: Early stopping conditioned on metric val_macro_f1 which is not available. Pass in or modify your EarlyStopping callback to use any of the following: train_loss
```

The issue has to do with the `split` column. When we don't provide it in the labels, we use a random split. But we don't guarantee that we have all of the values from the split_proportions dict (e.g. `train` and `val` ) in the split column. With a small number of videos and the default proportions, all videos getting assigned to train (see in `splits.csv`). Since there are no val videos, there is no `val_f1_score`.

I considered implementing this without the random draw and instead calculating the number of samples that need to go into each split based on the proportions provided. However, this gets tricky to ensure based on rounding. I instead went with the while loop that tries different seeds until it finds a draw that works. If someone specifies split proportions of `train: 100, val: 1`, and only provides say 5 videos, there is risk of an infinite loop. I'm not sure how important it is to catch such a situation since 1) we don't expect people to be training on so few videos and 2) it feels hard to accidentally end up in such a situation.

**Bonus fix**: fix bug in ModelCheckpoint which lets monitor be None if there is no early stopping. `mode` must either be `min` or `max`. I set it to `min` to match PTL's default but it doesn't get used if monitor is None.

Plus cleanup to set defaults in `DummyTrainConfig` to avoid repeated code.