### PR TITLE
Remove unidentified from list of european species

### DIFF
--- a/docs/docs/models/species-detection.md
+++ b/docs/docs/models/species-detection.md
@@ -83,7 +83,6 @@ All models support training, fine-tuning, and inference. For fine-tuning, we rec
 * `european_roe_deer`
 * `north_american_raccoon`
 * `red_fox`
-* `unidentified`
 * `weasel`
 * `wild_boar`
 


### PR DESCRIPTION
Remove unidentified from list of species in Python package docs. TBD how this will surface in the latest docs vs. the stable docs.