### PR TITLE
Update path to pretrained yolox asset

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,21 +113,23 @@ jobs:
         run: |
           make dist
 
-      - name: Install wheel and test CLI
+      - name: Install wheel; test CLI + models with assets
         run: |
           python -m venv .venv-whl
           PYTHON_BIN=bin/python
           .venv-whl/$PYTHON_BIN -m pip install --upgrade pip
           .venv-whl/$PYTHON_BIN -m pip install dist/zamba-*.whl
           .venv-whl/$PYTHON_BIN -m zamba --help
+          .venv-whl/$PYTHON_BIN python -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
-      - name: Install source and test CLI
+      - name: Install source; test CLI + models with assets
         run: |
           python -m venv .venv-sdist
           PYTHON_BIN=bin/python
           .venv-sdist/$PYTHON_BIN -m pip install --upgrade pip
           .venv-sdist/$PYTHON_BIN -m pip install dist/zamba-*.tar.gz
           .venv-sdist/$PYTHON_BIN -m zamba --help
+          .venv-whl/$PYTHON_BIN python -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
   notify:
     name: Notify failed build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
           .venv-whl/$PYTHON_BIN -m pip install --upgrade pip
           .venv-whl/$PYTHON_BIN -m pip install dist/zamba-*.whl
           .venv-whl/$PYTHON_BIN -m zamba --help
-          .venv-whl/$PYTHON_BIN python -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
+          .venv-whl/$PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
       - name: Install source; test CLI + models with assets
         run: |
@@ -129,7 +129,7 @@ jobs:
           .venv-sdist/$PYTHON_BIN -m pip install --upgrade pip
           .venv-sdist/$PYTHON_BIN -m pip install dist/zamba-*.tar.gz
           .venv-sdist/$PYTHON_BIN -m zamba --help
-          .venv-whl/$PYTHON_BIN python -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
+          .venv-sdist/$PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
   notify:
     name: Notify failed build

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # `zamba` changelog
 
+## v2.0.2 (2021-12-21)
+
+Releasing to pick up #172.
+
+ - PR [#172](https://github.com/drivendataorg/zamba/pull/172) fixes bug where video loading that uses the YoloX model (all of the built in models) resulted in videos not being able to load.
+
+
 ## v2.0.1 (2021-12-15)
 
 Releasing to pick up #167 and #169.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include zamba/models/official_models/*/config.yaml
-include zamba/models/yolox_models/assets/yolox_nano_20210901.pth
+include zamba/object_detection/yolox/assets/yolox_nano_20210901.pth
 include zamba/models/densepose/assets/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = zamba
-version = 2.0.1
+version = 2.0.2
 author = DrivenData
 author_email = info@drivendata.org
 description = Zamba is a command line tool and Python package to identify animals in camera trap videos and train custom models for new species and habitats.


### PR DESCRIPTION
Videos weren't loading in latest version, and we were seeing a lot of these errors:

```
2021-12-17 01:11:44.274 | WARNING  | zamba.pytorch.dataloaders:__getitem__:118 - Video /data/blank3.mp4 could not be loaded. Using an array of all zeros instead.
```

Upon debugging, discovered this was because of the following stack trace:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/dist-packages/zamba/data/video.py", line 468, in load_video_frames
    mdlite = MegadetectorLiteYoloX(config=config.megadetector_lite_config)
  File "/usr/local/lib/python3.8/dist-packages/zamba/object_detection/yolox/megadetector_lite_yolox.py", line 88, in __init__
    checkpoint = torch.load(path, map_location=config.device)
  File "/usr/local/lib/python3.8/dist-packages/torch/serialization.py", line 594, in load
    with _open_file_like(f, 'rb') as opened_file:
  File "/usr/local/lib/python3.8/dist-packages/torch/serialization.py", line 230, in _open_file_like
    return _open_file(name_or_buffer, mode)
  File "/usr/local/lib/python3.8/dist-packages/torch/serialization.py", line 211, in __init__
    super(_open_file, self).__init__(open(name, mode))
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/dist-packages/zamba/object_detection/yolox/assets/yolox_nano_20210901.pth'
```

Looks like this was introduced when #167 was merged.

Added extra test to make sure YoloX can load so we will catch an error like this with CI in the future.

