### PR TITLE
Make changelog a clickable header in the docs index

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,11 +21,9 @@ Other documentation fixes also included.
 ### Previous model: Machine learning competition
 
 The algorithms used by `zamba` v1 were based on the winning solution from the
-[Pri-matrix Factorization](https://www.drivendata.org/competitions/49/deep-learning-camera-trap-animals/) machine learning
-competition, hosted by [DrivenData](https://www.drivendata.org/). Data for the competition was provided by the [Chimp&See project](https://www.chimpandsee.org/#/) and manually labeled by volunteers. The competition had over 300 participants and over 450 submissions throughout the three month challenge. The v1 algorithm was adapted from the winning competition submission, with some aspects changed during development to improve performance.
+[Pri-matrix Factorization](https://www.drivendata.org/competitions/49/deep-learning-camera-trap-animals/) machine learning competition, hosted by [DrivenData](https://www.drivendata.org/). Data for the competition was provided by the [Chimp&See project](https://www.chimpandsee.org/#/) and manually labeled by volunteers. The competition had over 300 participants and over 450 submissions throughout the three month challenge. The v1 algorithm was adapted from the winning competition submission, with some aspects changed during development to improve performance.
 
-The core algorithm in `zamba` v1 was a [stacked ensemble](https://en.wikipedia.org/wiki/Ensemble_learning#Stacking) which consisted of a first layer of models that were then combined into a final prediction in a second layer. The first level of the stack consisted of 5 `keras` deep
-learning models, whose individual predictions were combined in the second level
+The core algorithm in `zamba` v1 was a [stacked ensemble](https://en.wikipedia.org/wiki/Ensemble_learning#Stacking) which consisted of a first layer of models that were then combined into a final prediction in a second layer. The first level of the stack consisted of 5 `keras` deep learning models, whose individual predictions were combined in the second level
 of the stack to form the final prediction.
 
 In v2, the stacked ensemble algorithm from v1 is replaced with three more powerful [single-model options](models/species-detection.md): `time_distributed`, `slowfast`, and `european`. The new models utilize state-of-the-art image and video classification architectures, and are able to outperform the much more computationally intensive stacked ensemble model.

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ docs-setup:
 	| sed 's|https://zamba.drivendata.org/docs/stable/||g' \
 	> docs/docs/index.md
 
-	sed 's|https://zamba.drivendata.org/docs/stable/|../|g' HISTORY.md > docs/docs/changelog.md
+	sed 's|https://zamba.drivendata.org/docs/stable/|../|g' HISTORY.md > docs/docs/changelog/index.md
 
 ## Build the static version of the docs
 docs: docs-setup

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,12 +5,9 @@
 ### Previous model: Machine learning competition
 
 The algorithms used by `zamba` v1 were based on the winning solution from the
-[Pri-matrix Factorization](https://www.drivendata.org/competitions/49/deep-learning-camera-trap-animals/) machine learning
-competition, hosted by [DrivenData](https://www.drivendata.org/). Data for the competition was provided by the [Chimp&See project](https://www.chimpandsee.org/#/) and manually labeled by volunteers. The competition had over 300 participants and over 450 submissions throughout the three month challenge. The v1 algorithm was adapted from the winning competition submission, with some aspects changed during development to improve performance.
+[Pri-matrix Factorization](https://www.drivendata.org/competitions/49/deep-learning-camera-trap-animals/) machine learning competition, hosted by [DrivenData](https://www.drivendata.org/). Data for the competition was provided by the [Chimp&See project](https://www.chimpandsee.org/#/) and manually labeled by volunteers. The competition had over 300 participants and over 450 submissions throughout the three month challenge. The v1 algorithm was adapted from the winning competition submission, with some aspects changed during development to improve performance.
 
-The core algorithm in `zamba` v1 was a [stacked ensemble](https://en.wikipedia.org/wiki/Ensemble_learning#Stacking) which consisted of a first layer of models that were then combined into a final prediction in a second layer. The first level of the stack consisted of 5 `keras` deep
-learning models, whose individual predictions were combined in the second level
-of the stack to form the final prediction.
+The core algorithm in `zamba` v1 was a [stacked ensemble](https://en.wikipedia.org/wiki/Ensemble_learning#Stacking) which consisted of a first layer of models that were then combined into a final prediction in a second layer. The first level of the stack consisted of 5 `keras` deep learning models, whose individual predictions were combined in the second level of the stack to form the final prediction.
 
 In v2, the stacked ensemble algorithm from v1 is replaced with three more powerful [single-model options](models/species-detection.md): `time_distributed`, `slowfast`, and `european`. The new models utilize state-of-the-art image and video classification architectures, and are able to outperform the much more computationally intensive stacked ensemble model.
 

--- a/docs/docs/changelog/index.md
+++ b/docs/docs/changelog/index.md
@@ -1,13 +1,30 @@
 # `zamba` changelog
 
-## v2 (2021-10-22)
+## v2.0.2 (2021-12-21)
+
+Releasing to pick up #172.
+
+ - PR [#172](https://github.com/drivendataorg/zamba/pull/172) fixes bug where video loading that uses the YoloX model (all of the built in models) resulted in videos not being able to load.
+
+
+## v2.0.1 (2021-12-15)
+
+Releasing to pick up #167 and #169.
+
+ - PR [#169](https://github.com/drivendataorg/zamba/pull/169) fixes error in splitting data into train/test/val when only a few videos.
+ - PR [#167](https://github.com/drivendataorg/zamba/pull/167) refactors yolox into an `object_detection` module
+
+Other documentation fixes also included.
+
+## v2.0.0 (2021-10-22)
 
 ### Previous model: Machine learning competition
 
 The algorithms used by `zamba` v1 were based on the winning solution from the
 [Pri-matrix Factorization](https://www.drivendata.org/competitions/49/deep-learning-camera-trap-animals/) machine learning competition, hosted by [DrivenData](https://www.drivendata.org/). Data for the competition was provided by the [Chimp&See project](https://www.chimpandsee.org/#/) and manually labeled by volunteers. The competition had over 300 participants and over 450 submissions throughout the three month challenge. The v1 algorithm was adapted from the winning competition submission, with some aspects changed during development to improve performance.
 
-The core algorithm in `zamba` v1 was a [stacked ensemble](https://en.wikipedia.org/wiki/Ensemble_learning#Stacking) which consisted of a first layer of models that were then combined into a final prediction in a second layer. The first level of the stack consisted of 5 `keras` deep learning models, whose individual predictions were combined in the second level of the stack to form the final prediction.
+The core algorithm in `zamba` v1 was a [stacked ensemble](https://en.wikipedia.org/wiki/Ensemble_learning#Stacking) which consisted of a first layer of models that were then combined into a final prediction in a second layer. The first level of the stack consisted of 5 `keras` deep learning models, whose individual predictions were combined in the second level
+of the stack to form the final prediction.
 
 In v2, the stacked ensemble algorithm from v1 is replaced with three more powerful [single-model options](models/species-detection.md): `time_distributed`, `slowfast`, and `european`. The new models utilize state-of-the-art image and video classification architectures, and are able to outperform the much more computationally intensive stacked ensemble model.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,10 +5,7 @@
 [![codecov](https://codecov.io/gh/drivendataorg/zamba/branch/master/graph/badge.svg)](https://codecov.io/gh/drivendataorg/zamba)
 <!-- [![PyPI](https://img.shields.io/pypi/v/zamba.svg)](https://pypi.org/project/zamba/) -->
 
- 
-<div class="embed-responsive embed-responsive-16by9" width=500> 
-    <iframe width=600 height=340 class="embed-responsive-item" src="https://s3.amazonaws.com/drivendata-public-assets/monkey-vid.mp4" 
-frameborder="0" allowfullscreen=""></iframe></div>
+ <div class="embed-responsive embed-responsive-16by9" width=500>     <iframe width=600 height=340 class="embed-responsive-item" src="https://s3.amazonaws.com/drivendata-public-assets/monkey-vid.mp4" frameborder="0" allowfullscreen=""></iframe></div>
 
 > *Zamba* means "forest" in Lingala, a Bantu language spoken throughout the Democratic Republic of the Congo and the Republic of the Congo.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,7 +31,7 @@ nav:
   - "Contribute to zamba":
       - "contribute/index.md"
   - "Changelog":
-      - "changelog.md"
+      - "changelog/index.md"
   - API Reference:
       - zamba.data:
           - zamba.data.metadata: "api-reference/data-metadata.md"


### PR DESCRIPTION
This little PR makes "changelog" a clickable header in the docs table of content to mimic the behavior of other sections with only one page (e.g. contribute to zamba).

Bonus fix:
- remove extra line breaks in the history markdown file

## Before
<img width="225" alt="Screen Shot 2022-01-27 at 9 40 44 AM" src="https://user-images.githubusercontent.com/22667367/151413802-0b59de42-c04f-4aff-aef0-7dc7500f5171.png">

## After
<img width="225" alt="Screen Shot 2022-01-27 at 9 40 44 AM" src="https://user-images.githubusercontent.com/22667367/151413531-02866e2d-e01b-4376-835c-121d9c4831aa.png">

