### PR TITLE
Update expected bounding box in test based on new pillow version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,11 +56,12 @@ console_scripts =
 [options.extras_require]
 tests =
     coverage
+    Pillow>=9.0.0
     pytest
     pytest-coverage
     pytest-mock
     wheel
-densepose = 
+densepose =
     detectron2-densepose @ git+https://github.com/facebookresearch/detectron2@main#subdirectory=projects/DensePose
 
 [flake8]

--- a/tests/test_megadetector_lite_yolox.py
+++ b/tests/test_megadetector_lite_yolox.py
@@ -51,7 +51,7 @@ def test_detect_image(mdlite, dog):
     boxes, scores = mdlite.detect_image(np.array(dog))
 
     assert len(scores) == 1
-    assert np.allclose([0.09690314, 0.04301501, 0.9931333 , 1.0082883], boxes[0])
+    assert np.allclose([0.09690314, 0.04301501, 0.9931333, 1.0082883], boxes[0])
 
 
 def test_detect_video(mdlite, dog):

--- a/tests/test_megadetector_lite_yolox.py
+++ b/tests/test_megadetector_lite_yolox.py
@@ -51,7 +51,7 @@ def test_detect_image(mdlite, dog):
     boxes, scores = mdlite.detect_image(np.array(dog))
 
     assert len(scores) == 1
-    assert np.allclose([0.09714001, 0.04298288, 0.9931407, 1.0082585], boxes[0])
+    assert np.allclose([0.09690314, 0.04301501, 0.9931333 , 1.0082883], boxes[0])
 
 
 def test_detect_video(mdlite, dog):


### PR DESCRIPTION
`Pillow` is used by a number of our packages, including `detectron2-densepose`, `fvcore`, `pytorchvideo`, and `torchvision`.

The new release of pillow 9.0.0 (https://pypi.org/project/Pillow/#history) causes the `detect_image` test to fail ([example](https://github.com/drivendataorg/zamba/runs/4706439540?check_suite_focus=true)) as the outputted bounding boxes are slightly shifted. I've reproduced this issue locally and can confirm that pillow 8.4.0 yields `[0.09714001, 0.04298288, 0.9931407, 1.0082585]` whereas 9.0.0 yields `[0.09690314, 0.04301501, 0.9931333 , 1.0082883]`. 

This PR updates that test accordingly.