### PR TITLE
Separate out densepose install for contributing instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ tests:
 
 ## Run the tests that are just for densepose
 densepose-tests:
-	pytest tests/test_densepose.py tests/test_cli.py::test_densepose_cli_options -vv
+	ZAMBA_RUN_DENSEPOSE_TESTS=1 pytest tests/test_densepose.py tests/test_cli.py::test_densepose_cli_options -vv
 
 ## Set up python interpreter environment
 create_environment:

--- a/docs/docs/contribute/index.md
+++ b/docs/docs/contribute/index.md
@@ -20,6 +20,11 @@ $ cd zamba
 $ pip install -r requirements-dev.txt
 ```
 
+If your contribution is to the [DensePose](../models/densepose.md) model, you will need to install the additional dependencies with:
+```console
+$ pip install -e .[densepose]
+```
+
 ## Running the `zamba` test suite
 
 The included [`Makefile`](https://github.com/drivendataorg/zamba/blob/master/Makefile) contains code that uses pytest to run all tests in `zamba/tests`.
@@ -28,6 +33,11 @@ The command is (from the project root):
 
 ```console
 $ make tests
+```
+
+For [DensePose](../models/densepose.md) related tests, the command is:
+```console
+$ make densepose-tests
 ```
 
 ## Submit additional training videos

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -21,7 +21,7 @@ We recommend [Python installation using Anaconda](https://www.anaconda.com/downl
  - [macOS installation video](https://www.youtube.com/watch?v=nVlrpNf3EdM)
 
 
-#### FFmpeg version 4.3
+#### FFmpeg version 4
 
 [FFmpeg](https://ffmpeg.org/ffmpeg.html) is an open source library for loading videos of different codecs. Using FFmpeg means that `zamba` can be flexible in terms of the video formats we support. FFmpeg can be installed on all different platforms, but requires some additional configuration depending on the platform. Here are some videos and instructions walking through FFmpeg installation:
 
@@ -29,7 +29,8 @@ We recommend [Python installation using Anaconda](https://www.anaconda.com/downl
  - [Install on Ubuntu or Linux](https://www.tecmint.com/install-ffmpeg-in-linux/).
      - In the command line, enter `sudo apt update` and then `sudo apt install ffmpeg`.
  - [MacOS install video](https://www.youtube.com/watch?v=8nbuqYw2OCw&t=5s)
-     - First, install [Homebrew](https://brew.sh/). Then run `brew install ffmpeg`
+     - First, install [Homebrew](https://brew.sh/). Then run `brew install ffmpeg@4`
+     - Follow the brew instructions to add FFmpeg to your path.
 
 To check that `FFmpeg` is installed, run `ffmpeg`:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
--e .[tests,densepose]
+-e .[tests]
 
 -r requirements-dev/docs.txt
 -r requirements-dev/lint.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     pandas_path
     pydantic
     python-dotenv
-    pytorch-lightning
+    pytorch-lightning>=1.6.0
     pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo
     scikit-learn
     tensorboard

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,9 +188,9 @@ def test_actual_prediction_on_single_video(tmp_path):  # noqa: F811
 
 
 @pytest.mark.skipif(
-    not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
+    not bool(int(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", 0))),
     reason="""Skip the densepose specific tests unless environment variable \
-ZAMBA_RUN_DENSEPOSE_TESTS is set to True.""",
+ZAMBA_RUN_DENSEPOSE_TESTS is set to 1.""",
 )
 def test_densepose_cli_options(mocker):  # noqa: F811
     """Test CLI options that are shared between train and predict commands."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,8 +188,9 @@ def test_actual_prediction_on_single_video(tmp_path):  # noqa: F811
 
 
 @pytest.mark.skipif(
-    bool(os.environ.get("CI")) and not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
-    reason="Skip on CI if not running the densepose specific tests",
+    not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
+    reason="""Skip the densepose specific tests unless environment variable \
+ZAMBA_RUN_DENSEPOSE_TESTS is set to True.""",
 )
 def test_densepose_cli_options(mocker):  # noqa: F811
     """Test CLI options that are shared between train and predict commands."""

--- a/tests/test_densepose.py
+++ b/tests/test_densepose.py
@@ -22,9 +22,9 @@ def chimp_image_path():
 
 
 @pytest.mark.skipif(
-    not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
+    not bool(int(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", 0))),
     reason="""Skip the densepose specific tests unless environment variable \
-ZAMBA_RUN_DENSEPOSE_TESTS is set to True.""",
+ZAMBA_RUN_DENSEPOSE_TESTS is set to 1.""",
 )
 @pytest.mark.parametrize("model", ("animals", "chimps"))
 def test_image(model, chimp_image_path, tmp_path):
@@ -66,9 +66,9 @@ def test_image(model, chimp_image_path, tmp_path):
 
 
 @pytest.mark.skipif(
-    not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
+    not bool(int(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", 0))),
     reason="""Skip the densepose specific tests unless environment variable \
-ZAMBA_RUN_DENSEPOSE_TESTS is set to True.""",
+ZAMBA_RUN_DENSEPOSE_TESTS is set to 1.""",
 )
 @pytest.mark.parametrize("model", ("animals", "chimps"))
 def test_video(model, chimp_video_path, tmp_path):
@@ -112,9 +112,9 @@ def test_video(model, chimp_video_path, tmp_path):
 
 
 @pytest.mark.skipif(
-    not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
+    not bool(int(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", 0))),
     reason="""Skip the densepose specific tests unless environment variable \
-ZAMBA_RUN_DENSEPOSE_TESTS is set to True.""",
+ZAMBA_RUN_DENSEPOSE_TESTS is set to 1.""",
 )
 @pytest.mark.parametrize("model", ("animals", "chimps"))
 def test_denseposeconfig(model, tmp_path):

--- a/tests/test_densepose.py
+++ b/tests/test_densepose.py
@@ -22,8 +22,9 @@ def chimp_image_path():
 
 
 @pytest.mark.skipif(
-    bool(os.environ.get("CI")) and not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
-    reason="Skip on CI if not running the densepose specific tests",
+    not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
+    reason="""Skip the densepose specific tests unless environment variable \
+ZAMBA_RUN_DENSEPOSE_TESTS is set to True.""",
 )
 @pytest.mark.parametrize("model", ("animals", "chimps"))
 def test_image(model, chimp_image_path, tmp_path):
@@ -65,8 +66,9 @@ def test_image(model, chimp_image_path, tmp_path):
 
 
 @pytest.mark.skipif(
-    bool(os.environ.get("CI")) and not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
-    reason="Skip on CI if not running the densepose specific tests",
+    not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
+    reason="""Skip the densepose specific tests unless environment variable \
+ZAMBA_RUN_DENSEPOSE_TESTS is set to True.""",
 )
 @pytest.mark.parametrize("model", ("animals", "chimps"))
 def test_video(model, chimp_video_path, tmp_path):
@@ -110,8 +112,9 @@ def test_video(model, chimp_video_path, tmp_path):
 
 
 @pytest.mark.skipif(
-    bool(os.environ.get("CI")) and not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
-    reason="Skip on CI if not running the densepose specific tests",
+    not bool(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", False)),
+    reason="""Skip the densepose specific tests unless environment variable \
+ZAMBA_RUN_DENSEPOSE_TESTS is set to True.""",
 )
 @pytest.mark.parametrize("model", ("animals", "chimps"))
 def test_denseposeconfig(model, tmp_path):

--- a/tests/test_load_video_frames.py
+++ b/tests/test_load_video_frames.py
@@ -334,7 +334,7 @@ test_cases = [
 
 
 def get_video_metadata():
-    test_video_paths = [path for path in TEST_VIDEOS_DIR.rglob("*") if path.is_file()]
+    test_video_paths = sorted([path for path in TEST_VIDEOS_DIR.rglob("*") if path.is_file()])
     video_metadata = []
     for video_path in test_video_paths:
         frames, height, width, channels = load_video_frames(video_path).shape

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -164,7 +164,7 @@ def test_train_save_dir_overwrite(
         "train_configuration.yaml",
         "test_metrics.json",
         "val_metrics.json",
-        "epoch=0-step=10.ckpt",
+        "epoch=0-step=11.ckpt",
     ]:
         assert (config.save_dir / f).exists()
 


### PR DESCRIPTION
`requirements-dev.txt` no longer installs the densepose extra since DensePose requires torch to be installed first. The appropriate install and test commands for DensePose contributions are now laid out on the contributing page.

Bonus fixes
- update installation instructions to use v4 as brew will now install v5 by default
- skip densepose tests by default so that `make tests` runs with the default dev install. the verbose pytest will show that these tests are skipped