### PR TITLE
Add basic depth module to zamba

### DIFF
--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -511,7 +511,9 @@ def densepose(
 @app.command()
 def depth(
     filepaths: Path = typer.Option(
-        None, exists=True, help="Path to csv containing `filepath` column with videos."
+        None,
+        exists=True,
+        help="Path to csv containing `filepath` column with videos. Paths should be relative to the image directory",
     ),
     img_dir: Path = typer.Option(None, exists=True, help="Path to folder containing all images."),
     save_to: Path = typer.Option(

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -515,7 +515,7 @@ def depth(
         exists=True,
         help="Path to csv containing `filepath` column with videos. Paths should be relative to the image directory",
     ),
-    img_dir: Path = typer.Option(None, exists=True, help="Path to folder containing all images."),
+    img_dir: Path = typer.Option(None, exists=True, help="Path to folder containing all images"),
     save_to: Path = typer.Option(
         None,
         help="An optional directory or path for saving the output. Defaults to the current working directory",
@@ -532,11 +532,14 @@ def depth(
     ),
 ):
     """
-    Run depth estimation algorithm on images.
+    Run depth estimation algorithm on images. Must provide either a list of full filepaths, or relative
+    filepaths and an image directory.
     """
-    predict_dict = {"filepaths": filepaths, "img_dir": img_dir}
+    predict_dict = {"filepaths": filepaths}
 
     # override if any command line arguments are passed
+    if img_dir is not None:
+        predict_dict["img_dir"] = img_dir
     if save_to is not None:
         predict_dict["save_to"] = save_to
     if cache_dir is not None:

--- a/zamba/models/depth_estimation/__init__.py
+++ b/zamba/models/depth_estimation/__init__.py
@@ -1,0 +1,2 @@
+from .depth_manager import DepthEstimationManager  # noqa
+from .config import DepthEstimationConfig  # noqa

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from pydantic.class_validators import root_validator, validator
+from typing import Optional
+
+from zamba.models.config import (
+    ZambaBaseModel,
+    check_files_exist_and_load,
+    validate_model_cache_dir,
+)
+
+
+class DepthEstimationConfig(ZambaBaseModel):
+    filepaths: Optional[
+        Path
+    ] = None  # Path to a CSV file with a list of filepaths to process. In this case, for each image for prediction there should be five filepaths (so we don't have to save duplicate information in image arrays). columns can be frame_0, frame_1, frame_2, frame_3, and frame_4 - frame 3 will be the target frame. or for now can only take in one, but then would only predict on one at a time - csv is better with all five columns
+    save_dir: Optional[
+        Path
+    ] = None  # Directory for where to save the output files; defaults to os.getcwd().
+    cache_dir: Optional[
+        Path
+    ] = None  # Path for downloading and saving model weights. Defaults to env var `MODEL_CACHE_DIR` or the OS app cache dir.
+    tta: int  # assert 1 <= args.tta <= 2, args.tta in test.py, add validation for that
+
+    @root_validator(pre=False, skip_on_failure=True)
+    def get_filepaths(cls, values):
+        """If no file list is passed, get all files in data directory. Warn if there
+        are unsupported suffixes. Filepaths is set to a dataframe, where column `filepath`
+        contains files with valid suffixes.
+        """
+        # likely will want to return a list of lists, where each one is the list of five filepaths for the target image
+        pass  # pull from densepose config
+
+    @root_validator(skip_on_failure=True)
+    def validate_files(cls, values):
+        pass  # pull from densepose config
+
+    def run_model(self):
+        # this is what will be called from the CLI
+
+        # model = ...
+
+        # set other args that are inputs to DepthManager
+
+        # dm = DepthManager(...)
+
+        # for fp_list in filepaths_list:
+        # load five images and stack into an array
+        # predict on stacked images
+        # save out labels
+
+        pass

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -79,10 +79,6 @@ class DepthEstimationConfig(ZambaBaseModel):
 
     @root_validator(skip_on_failure=True)
     def validate_files(cls, values):
-        # set image directory if only full filepaths are provided
-        if values["img_dir"] is None:
-            values["img_dir"] = Path(values["filepaths"][0]).parent
-
         # check for duplicates
         if len(values["filepaths"]) != len(set(values["filepaths"])):
             logger.warning(
@@ -92,7 +88,7 @@ class DepthEstimationConfig(ZambaBaseModel):
 
         files_df = pd.DataFrame({"filepath": values["filepaths"]})
         values["filepaths"] = check_files_exist_and_load(
-            df=files_df, data_dir=values["img_dir"], skip_load_validation=True
+            df=files_df, skip_load_validation=True, data_dir=None
         ).filepath.values.tolist()
 
         return values

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -1,51 +1,89 @@
+import os
+
+from loguru import logger
+import pandas as pd
 from pathlib import Path
 from pydantic.class_validators import root_validator, validator
-from typing import Optional
+from typing import Optional, Union, List
 
 from zamba.models.config import (
     ZambaBaseModel,
     check_files_exist_and_load,
     validate_model_cache_dir,
 )
+from zamba.models.depth_estimation.depth_manager import DepthEstimationManager
+
+# Union[
+#     Path, List[Union[Path, str]]
+# ]  # either a path to a df with one column for filepath or a list of filepaths
 
 
 class DepthEstimationConfig(ZambaBaseModel):
-    filepaths: Optional[
-        Path
-    ] = None  # Path to a CSV file with a list of filepaths to process. In this case, for each image for prediction there should be five filepaths (so we don't have to save duplicate information in image arrays). columns can be frame_0, frame_1, frame_2, frame_3, and frame_4 - frame 3 will be the target frame. or for now can only take in one, but then would only predict on one at a time - csv is better with all five columns
-    save_dir: Optional[
-        Path
-    ] = None  # Directory for where to save the output files; defaults to os.getcwd().
-    cache_dir: Optional[
-        Path
-    ] = None  # Path for downloading and saving model weights. Defaults to env var `MODEL_CACHE_DIR` or the OS app cache dir.
-    tta: int  # assert 1 <= args.tta <= 2, args.tta in test.py, add validation for that
+    """_summary_
+
+    Args:
+        ZambaBaseModel (_type_): _description_
+        save_to: # Directory for where to save the output files; defaults to os.getcwd(). If a path will save to that path, if a directory will save to depth_predictions.csv in that directory. Defaults to os.getcwd() directory.
+
+        cache_dir: # Path for downloading and saving model weights. Defaults to env var `MODEL_CACHE_DIR` or the OS app cache dir. <-- TODO update
+
+        batch_size # 256 in winning code, may want to change this
+
+    Raises:
+        ValueError: _description_
+
+    Returns:
+        _type_: _description_
+    """
+
+    filepaths: Union[Path, List[Union[Path, str]]]
+    img_dir: Optional[Path]
+    save_to: Optional[Path] = None
+    cache_dir: Optional[Path] = Path(".zamba_cache")
+    batch_size: Optional[int] = 64
+
+    _validate_cache_dir = validator("cache_dir", allow_reuse=True, always=True)(
+        validate_model_cache_dir
+    )
+
+    def run_model(self):
+        # get path to save predictions
+        if self.save_to is None:
+            save_path = Path(os.getcwd()) / "depth_predictions.csv"
+        elif self.save_to.suffix:
+            save_path = self.save_to
+        else:
+            save_path = self.save_to / "depth_predictions.csv"
+        if save_path.exists():
+            logger.warning(f"Predictions will NOT be saved out because {save_path} already exists")
+        else:
+            logger.info(f"Predictions will be saved to {save_path}")
+
+        logger.info("Instantiating depth manager")
+        dm = DepthEstimationManager(
+            img_dir=self.img_dir,
+            model_cache_dir=self.cache_dir,
+            batch_size=self.batch_size,
+        )
+
+        logger.info("Generating depth predictions")
+        predictions = dm.predict(self.filepaths)
+
+        predictions.to_csv(save_path, index=False)
+        logger.info(f"Depth predictions saved to {save_path}")
 
     @root_validator(pre=False, skip_on_failure=True)
     def get_filepaths(cls, values):
-        """If no file list is passed, get all files in data directory. Warn if there
-        are unsupported suffixes. Filepaths is set to a dataframe, where column `filepath`
-        contains files with valid suffixes.
-        """
-        # likely will want to return a list of lists, where each one is the list of five filepaths for the target image
-        pass  # pull from densepose config
+        # load the filepaths if a path to a csv is provided
+        if isinstance(values["filepaths"], Path):
+            files_df = pd.read_csv(values["filepaths"])
+            if "filepath" not in files_df.columns:
+                raise ValueError(f"{values['filepaths']} must contain a `filepath` column.")
+            values["filepaths"] = files_df["filepath"].values.tolist()
 
-    @root_validator(skip_on_failure=True)
-    def validate_files(cls, values):
-        pass  # pull from densepose config
+        return values
 
-    def run_model(self):
-        # this is what will be called from the CLI
-
-        # model = ...
-
-        # set other args that are inputs to DepthManager
-
-        # dm = DepthManager(...)
-
-        # for fp_list in filepaths_list:
-        # load five images and stack into an array
-        # predict on stacked images
-        # save out labels
-
-        pass
+    # @root_validator(skip_on_failure=True)
+    # def validate_files(cls, values):
+    #     # check for duplicates
+    #     if len(self.filepaths)

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -10,7 +10,7 @@ import torch
 import torch.utils
 import torch.utils.data
 import tqdm
-from typing import Optional, Union
+from typing import Union
 
 
 def imread(path):

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -52,7 +52,7 @@ class DepthDataset(torch.utils.data.Dataset):
         """Given the index of the target image, returns a tuple of the stacked image array, the image
         filename stem, and the time into the video for the target image.
         """
-        target_image_path = self.filepaths[index]
+        target_image_path = Path(self.filepaths[index])
 
         img = imread(target_image_path)
         inputs = {"image": img}

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -140,7 +140,7 @@ class DepthEstimationManager:
         self.use_log = use_log
 
     def predict(self, filepaths):
-        """Generate predictions for a list of filepaths, each representing one target frame"""
+        """Generate predictions for a list of filepaths, each representing one target frame. Filepaths should be given relative to the img_dir"""
         torch.backends.cudnn.benchmark = True
 
         # load model

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -86,7 +86,7 @@ class DepthDataset(torch.utils.data.Dataset):
         img = np.concatenate([inputs[i] for i in self.order], axis=-1)
         img = normalize(img)
 
-        return img, target_image_path, time
+        return img, str(target_image_path), time
 
 
 class DepthEstimationManager:

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -131,6 +131,8 @@ class DepthEstimationManager:
         # automatically use CPU if no cuda available
         if not torch.cuda.is_available():
             self.device = "cpu"
+        else:
+            self.device = "gpu"
 
         self.img_dir = img_dir
         self.batch_size = batch_size

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -132,7 +132,7 @@ class DepthEstimationManager:
         if not torch.cuda.is_available():
             self.device = "cpu"
         else:
-            self.device = "gpu"
+            self.device = "cuda"
 
         self.img_dir = img_dir
         self.batch_size = batch_size

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -37,9 +37,8 @@ def download_from_s3(
 
 
 class DepthDataset(torch.utils.data.Dataset):
-    def __init__(self, filepaths, img_dir, window_size):
+    def __init__(self, filepaths, window_size):
         self.filepaths = filepaths
-        self.img_dir = img_dir
         self.window_size = window_size
         self.order = [f"image_{i}" for i in range(1, window_size + 1)]
         self.order.append("image")
@@ -147,7 +146,7 @@ class DepthEstimationManager:
         model = torch.jit.load(self.model_weights, map_location=self.device).eval()
 
         # load dataset
-        test_dataset = DepthDataset(filepaths, img_dir=self.img_dir, window_size=self.window_size)
+        test_dataset = DepthDataset(filepaths, window_size=self.window_size)
         test_loader = torch.utils.data.DataLoader(
             test_dataset,
             batch_size=self.batch_size,

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -141,7 +141,7 @@ class DepthEstimationManager:
         self.use_log = use_log
 
     def predict(self, filepaths):
-        """Generate predictions for a list of filepaths, each representing one target frame. 
+        """Generate predictions for a list of filepaths, each representing one target frame.
         Filepaths should be given relative to the img_dir."""
         torch.backends.cudnn.benchmark = True
 

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -1,0 +1,186 @@
+import json
+import os
+
+from cloudpathlib import S3Path, S3Client
+import cv2
+import dotenv
+from loguru import logger
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import torch
+import torch.utils
+import torch.utils.data
+import tqdm
+from typing import Optional, Union
+
+# dotenv_path = Path(__file__).parents[3].resolve() / ".env"
+# dotenv.load_dotenv(dotenv_path)
+
+
+def imread(path):
+    img = cv2.imread(str(path))
+
+    return img
+
+
+def normalize(img):
+    img = np.transpose(img, (2, 0, 1))
+    img = img.astype("float32") / 255
+    img = torch.from_numpy(img)
+
+    return img
+
+
+def download_from_s3(
+    filepath: str,
+    destination_dir: Union[os.PathLike, str],
+):
+    s3p = S3Path(filepath, client=S3Client(local_cache_dir=destination_dir))
+
+    return s3p.fspath
+
+
+class DepthDataset(torch.utils.data.Dataset):
+    def __init__(self, df, img_dir, window_size):
+        self.df = df  # one column for filepath of the image
+        self.img_dir = img_dir
+        self.window_size = window_size
+        self.order = [f"image_{i}" for i in range(1, window_size + 1)]
+        self.order.append("image")
+        self.order.extend([f"image{i}" for i in range(1, window_size + 1)])
+
+    def __len__(self):
+        return len(self.df)
+
+    def __getitem__(self, index):
+        # returns a tuple of the image, the image filename stem, and the time into the video
+        target_image_path = self.df.iloc[index][0]
+
+        img = imread(target_image_path)
+        inputs = {"image": img}
+
+        time = int(target_image_path.stem.split("_")[-1])
+        stem = "_".join(target_image_path.stem.split("_")[:-1])
+
+        if self.window_size > 0:
+            suffix = target_image_path.suffix
+            for i in range(1, self.window_size + 1):
+                s = time - i
+                if s >= 0:
+                    new_stem = "_".join([stem, str(s)])
+                    new_name = f"{new_stem}{suffix}"
+                    new_path = target_image_path.with_name(new_name)
+                    inputs[f"image_{i}"] = imread(new_path)
+                # pad images if before beginning
+                else:
+                    inputs[f"image_{i}"] = np.zeros_like(img)
+
+                s = time + i
+                new_stem = "_".join([stem, str(s)])
+                new_name = f"{new_stem}{suffix}"
+                new_path = target_image_path.with_name(new_name)
+                if new_path.is_file():
+                    inputs[f"image{i}"] = imread(new_path)
+
+                # pad images if past end
+                else:
+                    inputs[f"image{i}"] = np.zeros_like(img)
+
+        # concatenate filepaths in the correct order
+        img = np.concatenate([inputs[i] for i in self.order], axis=-1)
+        img = normalize(img)
+
+        return img, stem, time
+
+
+class DepthEstimationManager:
+    def __init__(
+        self,
+        tta: int,
+        img_dir: Optional[Path] = Path("data/benjamin_distance_detections/"),
+        model_s3_path: Optional[Path] = S3Path(
+            "s3://drivendata-client-zamba/depth_estimation_winner_weights/second_place/tf_efficientnetv2_l_in21k_2_5_pl4/model_best.pt"
+        ),
+        model_cache_dir: Path = Path(".zamba_cache"),
+        batch_size: Optional[int] = 256,  # likely will want to change this
+        window_size: Optional[int] = 2,
+        use_log: Optional[bool] = True
+        # all args that we will get from config, written out individually
+    ):
+        # maybe validate that 1<= tta <= 2
+
+        # import model weights
+        model_weights_path = model_cache_dir / str(model_s3_path).replace("s3://", "")
+        if not model_weights_path.exists():
+            logger.info(f"Downloading model weights from {model_s3_path}")
+            model_cache_dir.mkdir(parents=True, exist_ok=True)
+            self.model_weights = download_from_s3(model_s3_path, model_cache_dir)
+        else:
+            self.model_weights = model_weights_path
+        logger.info(f"Using model downloaded at {self.model_weights}")
+
+        # automatically use CPU if no cuda available
+        if not torch.cuda.is_available():
+            self.device = "cpu"
+
+        self.img_dir = img_dir
+        self.batch_size = batch_size
+        self.window_size = window_size
+        self.tta = tta
+        self.use_log = use_log
+
+    def predict(self, df):
+        # predict from dataframe with one row per target image and one column with filepath
+        torch.backends.cudnn.benchmark = True
+
+        # load model
+        model = torch.jit.load(self.model_weights, map_location=self.device).eval()
+
+        # load dataset
+        test_dataset = DepthDataset(df, img_dir=self.img_dir, window_size=self.window_size)
+        test_loader = torch.utils.data.DataLoader(
+            test_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            sampler=None,
+            collate_fn=None,
+            num_workers=min(self.batch_size, 8),
+            pin_memory=False,
+            persistent_workers=True,
+        )
+
+        predictions = []
+        with torch.no_grad():
+            with tqdm.tqdm(test_loader) as pbar:
+                distance: torch.Tensor = torch.zeros(self.batch_size, device=self.device)
+                for image, filepath_stem, time in pbar:
+                    bs = image.size(0)
+                    image = image.to(self.device, non_blocking=True)
+
+                    distance.zero_()
+                    logits = model(image)
+                    logits = logits.squeeze(1)
+                    distance[:bs] += logits
+
+                    if self.tta > 1:
+                        logits = model(torch.flip(image, dims=[-1]))
+                        logits = logits.squeeze(1)
+                        distance[:bs] += logits
+
+                    distance /= self.tta
+
+                    if self.use_log:
+                        distance.expm1_()
+
+                    time = time.numpy()
+
+                    for d, vid, t in zip(distance.cpu().numpy(), filepath_stem, time):
+                        predictions.append((vid, t, d))
+
+        predictions = pd.DataFrame(
+            predictions,
+            columns=["filepath_stem", "time", "distance"],
+        )
+
+        return predictions


### PR DESCRIPTION
### Not ready to merge into master

The currently functionality is basic and geared towards what is needed to run a full pipeline based on the megadetector output. Before adding as a full zamba module, we'll need to add tests and more flexibility in usage - tracked in PJMF issue [#57](https://codetree.com/projects/MBWH/board/14035982?status=). Depth estimation module is added under `zamba/models/depth_estimation`. PJMF zamba [#43](https://codetree.com/projects/MBWH/board/14019598?status=)

### To run on the megadetector videos

1. Save a csv with one column, `filepaths`, with a list of the full filepaths from `benjamin_distance_detections` that actually have detections
2. Run `zamba depth --filepaths <path to csv> `

The predictions will save out to `depth_predictions.csv` in the current working directory (can specify otherwise with `--save-to`). The predictions will have columns for the image filename stem, seconds into the video, and predicted depth. Eg if the filepaths CSV includes:
```
filepath
data/interim/megadetector/benjamin_distance_detections/Pan troglodytes verus_5729_16541_13.jpg
data/interim/megadetector/benjamin_distance_detections/Chlorocebus sabaeus_1789254_1432_10.jpg
```
The predictions would include:
```
filepath_stem,time,distance
Pan troglodytes verus_5729_16541,13,5.227373
Chlorocebus sabaeus_1789254_1432,10,11.201744
```

Checks:
- [x] Verified that the depth prediction in zamba gives the same results as the unchanged competitor code on a small sample from the competition

### Notes

- We want depth to be able to accept just a list of full filepaths without an image directory. To allow this, I adjusted `zamba.models.config.check_files_exist_and_load` so that `data_dir` is an optional argument, and is only preprended to the list of filepaths if it is given
- There is a mistake in the winner's code where the stacked images are not in the right order - the first two are switched. The mistake is preserved in our code so that the model weights still apply correctly. See `DepthDataset.__getitem__` in `depth_estimation/depth_manager.py`
- Depth estimation doesn't require any additional packages that aren't already imported with regular zamba
