### PR TITLE
Pin version for ffmpeg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,11 +95,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v1
+        uses: Iamshankhadeep/setup-ffmpeg@v1.1
         with:
           # Not strictly necessary, but it may prevent rate limit
           # errors especially on GitHub-hosted macos machines.
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: "4.4"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup FFmpeg
-        uses: Iamshankhadeep/setup-ffmpeg@v1
+        uses: Iamshankhadeep/setup-ffmpeg@v1.1
         with:
           # Not strictly necessary, but it may prevent rate limit
           # errors especially on GitHub-hosted macos machines.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v1
+        uses: Iamshankhadeep/setup-ffmpeg@v1
         with:
           # Not strictly necessary, but it may prevent rate limit
           # errors especially on GitHub-hosted macos machines.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           # Not strictly necessary, but it may prevent rate limit
           # errors especially on GitHub-hosted macos machines.
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: "4.4"
 
       - name: Configure Windows compilers
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
Set the ffmpeg version in the github action workflow since zamba is only supported with ffmpeg v4.

Closes #184