### PR TITLE
Exclude extra columns in labels df (TrainConfig) and filepaths df (PredictConfig)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,29 @@ def test_label_column(tmp_path, labels_absolute_path):
     assert "must contain `filepath` and `label` columns" in error.value.errors()[0]["msg"]
 
 
+def test_extra_column(tmp_path, labels_absolute_path):
+    # add extra column that has species_ prefix
+    df = pd.read_csv(labels_absolute_path)
+    df["species_VE"] = "duiker"
+    df.to_csv(
+        tmp_path / "extra_species_col.csv",
+        index=False,
+    )
+    # this column is not one hot encoded
+    config = TrainConfig(labels=tmp_path / "extra_species_col.csv")
+    assert list(config.labels.columns) == [
+        "filepath",
+        "split",
+        "species_antelope_duiker",
+        "species_elephant",
+        "species_gorilla",
+    ]
+
+    # extra columns are excluded in predict config
+    config = PredictConfig(filepaths=tmp_path / "extra_species_col.csv")
+    assert config.filepaths.columns == ["filepath"]
+
+
 def test_one_video_does_not_exist(tmp_path, labels_absolute_path, caplog):
     files_df = pd.read_csv(labels_absolute_path)
     # add a fake file

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -423,6 +423,10 @@ class TrainConfig(ZambaBaseModel):
         if not set(["label", "filepath"]).issubset(labels.columns):
             raise ValueError(f"{values['labels']} must contain `filepath` and `label` columns.")
 
+        # subset to required and optional
+        cols_to_keep = [c for c in labels.columns if c in ["filepath", "label", "site", "split"]]
+        labels = labels[cols_to_keep]
+
         # validate split column has no partial nulls or invalid values
         if "split" in labels.columns:
 
@@ -723,6 +727,8 @@ class PredictConfig(ZambaBaseModel):
 
         if "filepath" not in files_df.columns:
             raise ValueError(f"{values['filepaths']} must contain a `filepath` column.")
+        else:
+            files_df = files_df[["filepath"]]
 
         # can only contain one row per filepath
         num_duplicates = len(files_df) - files_df.filepath.nunique()


### PR DESCRIPTION
For the labels csv, we required "filepath" and "label" and support optional columns "split" and/or "site." If a labels csv contains extra columns, we should exclude those as these can lead to unintended consequences.

For example, if there is a column with "species_" prefix, e.g. "species_VE", this column will get included in the species list (which results from label -> species -> get dummies -> filter columns with "species_"). By explicitly excluding extra columns, we avoid this bug.

Similarly for predict, we should exclude any columns that are not "filepath" as this interferes with indexing in the dataloader.