### PR TITLE
Use strategy instead of accelerator

### DIFF
--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -268,7 +268,7 @@ def train_model(
         logger=tensorboard_logger,
         callbacks=callbacks,
         fast_dev_run=train_config.dry_run,
-        accelerator="ddp" if data_module.multiprocessing_context is not None else None,
+        strategy="ddp" if data_module.multiprocessing_context is not None else None,
         plugins=DDPPlugin(find_unused_parameters=False)
         if data_module.multiprocessing_context is not None
         else None,


### PR DESCRIPTION
Addresses deprecation warning:

```
LightningDeprecationWarning: Passing <pytorch_lightning.plugins.training_type.ddp.DDPPlugin object at 0x7f9b62e37cd0> `strategy` to the `plugins` flag in Trainer has been deprecated in v1.5 and will be removed in v1.7. Use `Trainer(strategy=<pytorch_lightning.plugins.training_type.ddp.DDPPlugin object at 0x7f9b62e37cd0>)` instead.
```