### PR TITLE
Fix caching

### DIFF
--- a/tests/test_densepose.py
+++ b/tests/test_densepose.py
@@ -60,7 +60,7 @@ def test_image(model, chimp_image_path, tmp_path):
         )
 
         # output to disk
-        assert anatomy_info.shape == (2, 44)
+        assert anatomy_info.shape == (1, 44)
         assert (anatomy_info > 0).any().any()
         assert (tmp_path / f"anatomized_{model}.csv").stat().st_size > 0
 
@@ -106,7 +106,7 @@ def test_video(model, chimp_video_path, tmp_path):
         )
 
         # output to disk
-        assert anatomy_info.shape == (8, 46)
+        assert anatomy_info.shape == (10, 46)
         assert (anatomy_info > 0).any().any()
         assert (tmp_path / f"anatomized_{model}.csv").stat().st_size > 0
 

--- a/tests/test_densepose.py
+++ b/tests/test_densepose.py
@@ -60,7 +60,7 @@ def test_image(model, chimp_image_path, tmp_path):
         )
 
         # output to disk
-        assert anatomy_info.shape == (1, 44)
+        assert anatomy_info.shape == (2, 44)
         assert (anatomy_info > 0).any().any()
         assert (tmp_path / f"anatomized_{model}.csv").stat().st_size > 0
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -174,11 +174,6 @@ def test_train_save_dir_overwrite(
 def test_download_weights(model_name, weight_region, tmp_path):
     public_weights = get_model_checkpoint_filename(model_name)
 
-    if weight_region != "us":
-        region_bucket = f"drivendata-public-assets-{weight_region}"
-    else:
-        region_bucket = "drivendata-public-assets"
-
     ckpt_path = download_weights(
         filename=public_weights,
         weight_region=weight_region,

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -179,15 +179,16 @@ def test_download_weights(model_name, weight_region, tmp_path):
     else:
         region_bucket = "drivendata-public-assets"
 
-    fspath = download_weights(
+    ckpt_path = download_weights(
         filename=public_weights,
         weight_region=weight_region,
         destination_dir=tmp_path,
     )
-    # ensure weights exist
-    assert Path(fspath).exists()
+    # ensure download happened
+    assert Path(ckpt_path).exists()
+
     # ensure path is correct
-    assert Path(fspath) == tmp_path / region_bucket / "zamba_official_models" / public_weights
+    assert Path(ckpt_path) == tmp_path / public_weights
 
     # invalid filename
     with pytest.raises(ClientError):

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -172,6 +172,11 @@ def validate_model_name_and_checkpoint(cls, values):
             # get public weights file from official models config
             values["checkpoint"] = get_model_checkpoint_filename(model_name)
 
+            # if cached version exists, use that
+            cached_path = Path(values["model_cache_dir"]) / values["checkpoint"]
+            if cached_path.exists():
+                values["checkpoint"] = cached_path
+
     return values
 
 

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -78,9 +78,9 @@ def instantiate_model(
             hparams = yaml.safe_load(f)
 
     else:
-        # download if neither local checkpoint nor cached checkpoint exist
-        if not checkpoint.exists() and not (model_cache_dir / checkpoint).exists():
-            logger.info("Downloading weights for model.")
+        # download if checkpoint doesn't exist
+        if not checkpoint.exists():
+            logger.info(f"Downloading weights for model to {model_cache_dir}.")
             checkpoint = download_weights(
                 filename=str(checkpoint),
                 weight_region=weight_download_region,

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -34,7 +34,7 @@ def download_weights(
     )
 
     s3p.download_to(destination_dir)
-    return Path(destination_dir / s3p.name)
+    return str(Path(destination_dir / s3p.name))
 
 
 def get_model_checkpoint_filename(model_name):

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -32,7 +32,9 @@ def download_weights(
         f"{region_bucket}/zamba_official_models/{filename}",
         client=S3Client(local_cache_dir=destination_dir, no_sign_request=True),
     )
-    return s3p.fspath
+
+    s3p.download_to(destination_dir)
+    return Path(destination_dir / s3p.name)
 
 
 def get_model_checkpoint_filename(model_name):


### PR DESCRIPTION
Main changes:
- downloads public checkpoint file to top level model_cache_dir (this supports look ups in the correct place on future runs)
- if cached checkpoint file exists (and no other checkpoint was passed in), put the cached path on the `checkpoint` property in TrainConfig

These changes allow the previously downloaded file to actually get used on future runs. Previously, we were seeing "downloading model weights" on every run.

Closes #189 