### PR TITLE
Pin thop to avoid onnx dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,14 +31,14 @@ install_requires =
     openpyxl
     pandas>1.2.0
     pandas_path
-    protobuf==3.20.1
+    protobuf<=3.20.1
     pydantic
     python-dotenv
     pytorch-lightning>=1.6.0
     pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo
     scikit-learn
     tensorboard
-    thop
+    thop==0.0.31.post2005241907
     timm
     torch
     torchinfo


### PR DESCRIPTION
With the latest thop version released on June 10, 2022, `thop` requires onnx but doesn't install it. Our options are either to use an earlier version of thop or add the onnx dependency ourselves. Given that we don't need to use onnx, I've implemented the former.

The current error is as follows:
```
zamba --help
 ---> Running in f3d991f7f04a
Traceback (most recent call last):
  File "/usr/local/bin/zamba", line 5, in <module>
    from zamba.cli import app
  File "/usr/local/lib/python3.8/dist-packages/zamba/cli.py", line 10, in <module>
    from zamba.data.video import VideoLoaderConfig
  File "/usr/local/lib/python3.8/dist-packages/zamba/data/video.py", line 22, in <module>
    from zamba.object_detection.yolox.megadetector_lite_yolox import (
  File "/usr/local/lib/python3.8/dist-packages/zamba/object_detection/__init__.py", line 1, in <module>
    from zamba.object_detection.yolox.yolox_base import YoloXBase
  File "/usr/local/lib/python3.8/dist-packages/zamba/object_detection/yolox/yolox_base.py", line 4, in <module>
    from yolox.exp import Exp
  File "/usr/local/lib/python3.8/dist-packages/yolox/__init__.py", line 4, in <module>
    from .utils import configure_module
  File "/usr/local/lib/python3.8/dist-packages/yolox/utils/__init__.py", line 14, in <module>
    from .model_utils import *
  File "/usr/local/lib/python3.8/dist-packages/yolox/utils/model_utils.py", line 9, in <module>
    from thop import profile
  File "/usr/local/lib/python3.8/dist-packages/thop/__init__.py", line 3, in <module>
    from .onnx_profile import OnnxProfile
  File "/usr/local/lib/python3.8/dist-packages/thop/onnx_profile.py", line 3, in <module>
    import onnx
ModuleNotFoundError: No module named 'onnx'
```

This is further justification for setting up weekly test runs to catch this, per #188 

Bonus fix: use less than or equals for `protobuf` as this consistently gets downgraded to 3.19.*.