### PR TITLE
Fix bug in download_weights

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
  - Pins `thop` to an earlier version ([PR #191](https://github.com/drivendataorg/zamba/pull/191))
  - Fixes caching so a previously downloaded checkpoint file actually gets used ([PR #190](https://github.com/drivendataorg/zamba/pull/190), [PR #194](https://github.com/drivendataorg/zamba/pull/194))
- - Removes a lightning deprecation warning for DDP and sets a ceiling on `protobuf` for tensorboard ([PR #187](https://github.com/drivendataorg/zamba/pull/187))
+ - Removes a lightning deprecation warning for DDP ([PR #187](https://github.com/drivendataorg/zamba/pull/187))
  - Ignores extra columns in the user-provided labels or filepaths csv ([PR #186](https://github.com/drivendataorg/zamba/pull/186))
 
 ## v2.0.3 (2022-05-06)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## v2.0.4 (2022-06-17)
 
  - Pins `thop` to an earlier version ([PR #191](https://github.com/drivendataorg/zamba/pull/191))
- - Fixes caching so a previously downloaded checkpoint file actually gets used ([PR #190](https://github.com/drivendataorg/zamba/pull/190))
+ - Fixes caching so a previously downloaded checkpoint file actually gets used ([PR #190](https://github.com/drivendataorg/zamba/pull/190), [PR #194](https://github.com/drivendataorg/zamba/pull/194))
  - Removes a lightning deprecation warning for DDP and sets a ceiling on `protobuf` for tensorboard ([PR #187](https://github.com/drivendataorg/zamba/pull/187))
  - Ignores extra columns in the user-provided labels or filepaths csv ([PR #186](https://github.com/drivendataorg/zamba/pull/186))
 

--- a/docs/docs/changelog/index.md
+++ b/docs/docs/changelog/index.md
@@ -4,7 +4,7 @@
 
  - Pins `thop` to an earlier version ([PR #191](https://github.com/drivendataorg/zamba/pull/191))
  - Fixes caching so a previously downloaded checkpoint file actually gets used ([PR #190](https://github.com/drivendataorg/zamba/pull/190), [PR #194](https://github.com/drivendataorg/zamba/pull/194))
- - Removes a lightning deprecation warning for DDP and sets a ceiling on `protobuf` for tensorboard ([PR #187](https://github.com/drivendataorg/zamba/pull/187))
+ - Removes a lightning deprecation warning for DDP ([PR #187](https://github.com/drivendataorg/zamba/pull/187))
  - Ignores extra columns in the user-provided labels or filepaths csv ([PR #186](https://github.com/drivendataorg/zamba/pull/186))
 
 ## v2.0.3 (2022-05-06)

--- a/docs/docs/changelog/index.md
+++ b/docs/docs/changelog/index.md
@@ -3,7 +3,7 @@
 ## v2.0.4 (2022-06-17)
 
  - Pins `thop` to an earlier version ([PR #191](https://github.com/drivendataorg/zamba/pull/191))
- - Fixes caching so a previously downloaded checkpoint file actually gets used ([PR #190](https://github.com/drivendataorg/zamba/pull/190))
+ - Fixes caching so a previously downloaded checkpoint file actually gets used ([PR #190](https://github.com/drivendataorg/zamba/pull/190), [PR #194](https://github.com/drivendataorg/zamba/pull/194))
  - Removes a lightning deprecation warning for DDP and sets a ceiling on `protobuf` for tensorboard ([PR #187](https://github.com/drivendataorg/zamba/pull/187))
  - Ignores extra columns in the user-provided labels or filepaths csv ([PR #186](https://github.com/drivendataorg/zamba/pull/186))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ install_requires =
     openpyxl
     pandas>1.2.0
     pandas_path
-    protobuf<=3.20.1
     pydantic
     python-dotenv
     pytorch-lightning>=1.6.0

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -34,7 +34,7 @@ def download_weights(
     )
 
     s3p.download_to(destination_dir)
-    return str(Path(destination_dir / s3p.name))
+    return str(Path(destination_dir) / s3p.name)
 
 
 def get_model_checkpoint_filename(model_name):


### PR DESCRIPTION
Fix parenthesis so `destination_dir` is a `PosixPath`

Bonus fix:
- removes ceiling for `protobuf` since this is handled by the latest tensorboard release