### PR TITLE
Capitalize log level

### DIFF
--- a/docs/docs/debugging.md
+++ b/docs/docs/debugging.md
@@ -78,8 +78,8 @@ Reduce the number of workers (subprocesses) used for data loading. By default `n
 
 ## Logging
 
-To check that videos are getting loaded and cached as expected, set your environment variabe `LOG_LEVEL` to `debug`. The default log level is `info`. For example:
+To check that videos are getting loaded and cached as expected, set your environment variabe `LOG_LEVEL` to `DEBUG`. The default log level is `INFO`. For example:
 
 ```console
-$ LOG_LEVEL=debug zamba predict --data-dir example_vids/
+$ LOG_LEVEL=DEBUG zamba predict --data-dir example_vids/
 ```


### PR DESCRIPTION
The accepted loguru log levels are all caps. This PR fixes the documentation example so it runs correctly.

<img width="474" alt="image" src="https://user-images.githubusercontent.com/22667367/176949279-d0630f9d-8eae-42eb-bf28-4ad000a6fe5e.png">
