### PR TITLE
Support binary case

### DIFF
--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -491,6 +491,12 @@ class TrainConfig(ZambaBaseModel):
             .max()
         )
 
+        species_cols = labels.filter(regex="species_").columns
+        # binary case
+        if len(species_cols) == 2:
+            logger.warning(f"Binary case detected so only one species column will be kept. Output will be the binary case of {species_cols[0]}.")
+            labels = labels.drop(species_cols[1], axis=1)
+
         # if no "split" column, set up train, val, and holdout split
         if "split" not in labels.columns:
             logger.info(


### PR DESCRIPTION
If a user provides only two labels, we assume these are mutually exclusive and train the binary model. We log which column we're keeping.

Outstanding:
- [ ] tests
- [ ] documentation

Note: I gave this a quick try on a dataset of 100 videos balanced evenly between blank and non blank and we indeed see some learning.

```
      Validate metric             DataLoader 0
─────────────────────────────────────────────────────────
species/val_accuracy/blank            0.75
   species/val_f1/blank        0.7826086956521738
species/val_precision/blank    0.6923076923076923
 species/val_recall/blank              0.9
       val_accuracy                   0.75
         val_loss              0.6593988537788391
       val_macro_f1            0.7442455242966751
```