### PR TITLE
Include hparams in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include zamba/models/official_models/*/config.yaml
+include zamba/models/official_models/*/hparams.yaml
 include zamba/object_detection/yolox/assets/*
 include zamba/models/densepose/assets/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include zamba/models/official_models/*
+include zamba/models/official_models/*/*
 include zamba/object_detection/yolox/assets/*
 include zamba/models/densepose/assets/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include zamba/models/official_models/*/config.yaml
-include zamba/models/official_models/*/hparams.yaml
+include zamba/models/official_models/*
 include zamba/object_detection/yolox/assets/*
 include zamba/models/densepose/assets/*


### PR DESCRIPTION
Fix issue where `hparams.yaml` isn't included in the MANIFEST. Instead, let's just include all the files in the official models directory.

Without this, we get the following error (if not using an editable install)
```
FileNotFoundError: [Errno 2] No such file or directory: '.../python3.9/site-packages/zamba/models/official_models/time_distributed/hparams.yaml'
```