### PR TITLE
Add ability to set learning rate

### DIFF
--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -306,11 +306,11 @@ class TrainConfig(ZambaBaseModel):
             Disables tuners, checkpoint callbacks, loggers, and logger callbacks.
             Defaults to False.
         batch_size (int): Batch size to use for training. Defaults to 2.
-        auto_lr_find (bool): Use a learning rate finder algorithm when calling
-            trainer.tune() to try to find an optimal initial learning rate. Defaults to
-            False. The learning rate finder is not guaranteed to find a good learning
-            rate; depending on the dataset, it can select a learning rate that leads to
-            poor model training. Use with caution.
+        lr (bool): Learning rate for model. Defaults to 0.001. If "auto", use a
+            learning rate finder algorithm when calling trainer.tune() to try to
+            find an optimal initial learning rate. The learning rate finder is
+            not guaranteed to find a good learning rate; depending on the dataset,
+            it can select a learning rate that leads to poor model training. Use with caution.
         backbone_finetune_params (BackboneFinetuneConfig, optional): Set parameters
             to finetune a backbone model to align with the current learning rate.
             Defaults to a BackboneFinetuneConfig(unfreeze_backbone_at_epoch=5,
@@ -363,7 +363,7 @@ class TrainConfig(ZambaBaseModel):
     model_name: Optional[ModelEnum] = ModelEnum.time_distributed
     dry_run: Union[bool, int] = False
     batch_size: int = 2
-    auto_lr_find: bool = False
+    lr: Union[bool, float] = 0.001
     backbone_finetune_config: Optional[BackboneFinetuneConfig] = BackboneFinetuneConfig()
     gpus: int = GPUS_AVAILABLE
     num_workers: int = 3

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -306,7 +306,7 @@ class TrainConfig(ZambaBaseModel):
             Disables tuners, checkpoint callbacks, loggers, and logger callbacks.
             Defaults to False.
         batch_size (int): Batch size to use for training. Defaults to 2.
-        lr (bool): Learning rate for model. Defaults to 0.001. If "auto", use a
+        lr (float or str): Learning rate for model. Defaults to 0.001. If "auto", use a
             learning rate finder algorithm when calling trainer.tune() to try to
             find an optimal initial learning rate. The learning rate finder is
             not guaranteed to find a good learning rate; depending on the dataset,
@@ -363,7 +363,7 @@ class TrainConfig(ZambaBaseModel):
     model_name: Optional[ModelEnum] = ModelEnum.time_distributed
     dry_run: Union[bool, int] = False
     batch_size: int = 2
-    lr: Union[bool, float] = 0.001
+    lr: Union[float, str] = 0.001
     backbone_finetune_config: Optional[BackboneFinetuneConfig] = BackboneFinetuneConfig()
     gpus: int = GPUS_AVAILABLE
     num_workers: int = 3

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -280,9 +280,9 @@ def train_model(
     if train_config.lr == "auto":
         logger.info("Finding best learning rate.")
         trainer.tune(model, data_module)
-
     else:
         logger.info(f"Setting learning rate to {train_config.lr}.")
+        model.lr = train_config.lr
         model.hparams.lr = train_config.lr
 
     try:

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -263,7 +263,7 @@ def train_model(
     trainer = pl.Trainer(
         gpus=train_config.gpus,
         max_epochs=train_config.max_epochs,
-        auto_lr_find=train_config.auto_lr_find,
+        auto_lr_find=(train_config.lr == "auto"),
         logger=tensorboard_logger,
         callbacks=callbacks,
         fast_dev_run=train_config.dry_run,

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -277,9 +277,13 @@ def train_model(
     else:
         logger.info(f"Videos will be cached to {video_loader_config.cache_dir}.")
 
-    if train_config.auto_lr_find:
+    if train_config.lr == "auto":
         logger.info("Finding best learning rate.")
         trainer.tune(model, data_module)
+
+    else:
+        logger.info(f"Setting learning rate to {train_config.lr}.")
+        model.hparams.lr = train_config.lr
 
     try:
         git_hash = git.Repo(search_parent_directories=True).head.object.hexsha


### PR DESCRIPTION
We should be able to specify the learning rate the same way Lightning does after it finds the desired one with [auto_lr_find](https://pytorch-lightning.readthedocs.io/en/stable/advanced/training_tricks.html#learning-rate-finder). It's simpler to do it right before training rather than in model instantiation given how complicated the `instantiate_model` function is (because we're determining if we're starting from scratch, finetuning, replacing head, etc.).

This changes one TrainConfig param. Instead of `auto_lr_find`, there is just `lr` which can either be `auto` or a float (the desired learning rate).

Needs:
- [ ] testing
- [ ] documentation