### PR TITLE
Checking for missing files in parallel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     openpyxl
     pandas>1.2.0
     pandas_path
+    pqdm
     pydantic
     python-dotenv
     pytorch-lightning>=1.6.0


### PR DESCRIPTION
Closes #216 

Checking for missing files is slow with goofys. It seems to make lots of small queries to the file system. Running them in parallel with `pqdm` is much faster. The speed depends on the state of the file system cache, but we can check 246,000 files in 5-8 minutes, compared to about two hours the slow way.

Using `pqdm` with threads is faster than with processes. Using 16 threads seems to be fast and robust. With more threads, things go faster, but you start to see unpredictable I/O errors.

If an error occurs, it falls back to the slow way.

This fix has only been tested with video files that are mounted from S3 using goofys. It might be good to test with videos stored in a local file system, too.