### PR TITLE
Refactor branching structure for finetuning vs. resuming training

### DIFF
--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -277,7 +277,7 @@ class TrainConfig(ZambaBaseModel)
  overwrite: bool = False,
  skip_load_validation: bool = False,
  from_scratch: bool = False,
- predict_all_zamba_species: bool = True,
+ use_default_model_labels: bool = True,
  model_cache_dir: pathlib.Path = None) -> None
 
  ...
@@ -359,9 +359,9 @@ By default, before kicking off training `zamba` will iterate through all of the 
 
 Whether to instantiate the model with base weights. This means starting from the imagenet weights for image based models and the Kinetics weights for video models. Only used if labels is not None. Defaults to `False`
 
-#### `predict_all_zamba_species (bool, optional)`
+#### `use_default_model_labels (bool, optional)`
 
-Whether the species outputted by the model should be all zamba species. If you want the model classes to only be the species in your labels file, set to `False`. Only used if labels is not `None`. If either `predict_all_zamba_species` is `False` or the labels contain species that are not in the model, the model head will be replaced. Defaults to `True`
+Whether the species outputted by the model should be all zamba species. If you want the model classes to only be the species in your labels file, set to `False`. Only used if labels is not `None`. If either `use_default_model_labels` is `False` or the labels contain species that are not in the model, the model head will be replaced. Defaults to `True`
 
 #### `model_cache_dir (Path, optional)`
 

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -361,7 +361,7 @@ Whether to instantiate the model with base weights. This means starting from the
 
 #### `use_default_model_labels (bool, optional)`
 
-Whether the species outputted by the model should be all zamba species. If you want the model classes to only be the species in your labels file, set to `False`. Only used if labels is not `None`. If either `use_default_model_labels` is `False` or the labels contain species that are not in the model, the model head will be replaced. Defaults to `True`
+Whether the species outputted by the model should be the default model classes (e.g. all 32 species classes for the time_distributed model). If you want the model classes to only be the species in your labels file (e.g. just gorillas and elephants), set to `False`. If either `use_default_model_labels` is `False` or the labels contain species that are not in the model, the model head will be replaced for finetuning. Defaults to `True`
 
 #### `model_cache_dir (Path, optional)`
 

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -361,7 +361,7 @@ Whether to instantiate the model with base weights. This means starting from the
 
 #### `use_default_model_labels (bool, optional)`
 
-Whether the species outputted by the model should be the default model classes (e.g. all 32 species classes for the time_distributed model). If you want the model classes to only be the species in your labels file (e.g. just gorillas and elephants), set to `False`. If either `use_default_model_labels` is `False` or the labels contain species that are not in the model, the model head will be replaced for finetuning. Defaults to `True`
+Whether the species outputted by the model should be the default model classes (e.g. all 32 species classes for the `time_distributed` model). If you want the model classes to only be the species in your labels file (e.g. just gorillas and elephants), set to `False`. If either `use_default_model_labels` is `False` or the labels contain species that are not in the model, the model head will be replaced for finetuning. Defaults to `True`
 
 #### `model_cache_dir (Path, optional)`
 

--- a/tests/assets/sample_train_config.yaml
+++ b/tests/assets/sample_train_config.yaml
@@ -10,4 +10,3 @@ train_config:
   data_dir: tests/assets/videos
   labels: tests/assets/labels.csv
   model_name: time_distributed
-  predict_all_zamba_species: True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,8 +152,7 @@ def mdlite():
 def dummy_checkpoint(labels_absolute_path, tmp_path_factory) -> os.PathLike:
     tmp_path = tmp_path_factory.mktemp("dummy-model-dir")
     labels = pd.read_csv(labels_absolute_path)
-    # species will always be OHE with pd.get_dummies which alphabetizes
-    species = sorted(labels.label.unique())
+    species = labels.label.unique()
     output_path = tmp_path / "dummy.ckpt"
     DummyZambaVideoClassificationLightningModule(
         num_frames=4, num_hidden=1, species=species

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,7 +152,7 @@ def mdlite():
 def dummy_checkpoint(labels_absolute_path, tmp_path_factory) -> os.PathLike:
     tmp_path = tmp_path_factory.mktemp("dummy-model-dir")
     labels = pd.read_csv(labels_absolute_path)
-    species = labels.label.unique()
+    species = list(labels.label.unique())
     output_path = tmp_path / "dummy.ckpt"
     DummyZambaVideoClassificationLightningModule(
         num_frames=4, num_hidden=1, species=species

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -528,7 +528,7 @@ def test_validate_provided_species_and_use_default_model_labels(labels_absolute_
         save_dir=tmp_path / "my_model",
         use_default_model_labels=False,
     )
-    assert config.use_default_model_labels == False
+    assert config.use_default_model_labels is False
 
     # create labels with a species that is not in the model
     alien_labels = pd.read_csv(labels_absolute_path)
@@ -541,7 +541,7 @@ def test_validate_provided_species_and_use_default_model_labels(labels_absolute_
         save_dir=tmp_path / "my_model",
     )
     # by default this gets set to False
-    assert config.use_default_model_labels == False
+    assert config.use_default_model_labels is False
 
     # if I try to set this to True, it will error
     with pytest.raises(ValueError) as error:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -528,7 +528,7 @@ def test_validate_provided_species_and_use_default_model_labels(labels_absolute_
         save_dir=tmp_path / "my_model",
         use_default_model_labels=False,
     )
-    assert config.use_default_model_labels is False
+    assert config.use_default_model_labels == False
 
     # create labels with a species that is not in the model
     alien_labels = pd.read_csv(labels_absolute_path)
@@ -541,7 +541,7 @@ def test_validate_provided_species_and_use_default_model_labels(labels_absolute_
         save_dir=tmp_path / "my_model",
     )
     # by default this gets set to False
-    assert config.use_default_model_labels is False
+    assert config.use_default_model_labels == False
 
     # if I try to set this to True, it will error
     with pytest.raises(ValueError) as error:

--- a/tests/test_instantiate_model.py
+++ b/tests/test_instantiate_model.py
@@ -106,9 +106,9 @@ def test_head_not_replaced_for_species_subset(dummy_trained_model_checkpoint, tm
     assert model.model[-1].out_features == 3
 
 
-def test_not_predict_all_zamba_species(dummy_trained_model_checkpoint, tmp_path):
+def test_not_use_default_model_labels(dummy_trained_model_checkpoint, tmp_path):
     """Tests that training a model using labels that are a subset of the model species but
-    with predict_all_zamba_species=False replaces the model head."""
+    with use_default_model_labels=False replaces the model head."""
     original_model = DummyZambaVideoClassificationLightningModule.from_disk(
         dummy_trained_model_checkpoint
     )
@@ -119,7 +119,7 @@ def test_not_predict_all_zamba_species(dummy_trained_model_checkpoint, tmp_path)
         scheduler_config="default",
         labels=pd.DataFrame([{"filepath": "gorilla.mp4", "species_gorilla": 1}]),
         model_cache_dir=tmp_path,
-        predict_all_zamba_species=False,
+        use_default_model_labels=False,
     )
 
     assert (model.head.weight != original_model.head.weight).all()

--- a/tests/test_instantiate_model.py
+++ b/tests/test_instantiate_model.py
@@ -122,7 +122,6 @@ def test_head_replaced_for_new_species(
 ):
     """Tests that training a model using labels that are a not subset of the model species
     finetunes the model and replaces the model head."""
-
     original_model = DummyZambaVideoClassificationLightningModule.from_disk(
         dummy_trained_model_checkpoint
     )

--- a/tests/test_instantiate_model.py
+++ b/tests/test_instantiate_model.py
@@ -120,8 +120,8 @@ def test_not_use_default_model_labels(dummy_trained_model_checkpoint):
 def test_head_replaced_for_new_species(labels_absolute_path, model, tmp_path):
     """Tests that training a model using labels that are a not subset of the model species
     finetunes the model and replaces the model head."""
-    labels = pd.read_csv(labels_absolute_path)
     # pick species that is not present in any models
+    labels = pd.read_csv(labels_absolute_path)
     labels["label"] = "kangaroo"
 
     config = TrainConfig(
@@ -142,10 +142,8 @@ def test_head_replaced_for_new_species(labels_absolute_path, model, tmp_path):
 
 @pytest.mark.parametrize("model", ["time_distributed", "slowfast", "european"])
 def test_resume_subset_labels(labels_absolute_path, model, tmp_path):
-    # note: there are no additional species to add for the blank_nonblank model so it is not tested
-
-    labels = pd.read_csv(labels_absolute_path)
     # pick species that is present in all models
+    labels = pd.read_csv(labels_absolute_path)
     labels["label"] = "bird"
 
     config = TrainConfig(

--- a/tests/test_instantiate_model.py
+++ b/tests/test_instantiate_model.py
@@ -153,8 +153,13 @@ def test_finetune_new_labels(labels_absolute_path, model, tmp_path):
 @pytest.mark.parametrize("model", ["time_distributed", "slowfast", "european"])
 def test_resume_subset_labels(labels_absolute_path, model, tmp_path):
     # note: there are no additional species to add for the blank_nonblank model so it is not tested
+
+    labels = pd.read_csv(labels_absolute_path)
+    # pick species that is present in all models
+    labels["label"] = "bird"
+
     config = TrainConfig(
-        labels=labels_absolute_path,
+        labels=labels,
         model_name=model,
         skip_load_validation=True,
         save_dir=tmp_path / "my_model",
@@ -162,8 +167,8 @@ def test_resume_subset_labels(labels_absolute_path, model, tmp_path):
     model = instantiate_model(
         checkpoint=config.checkpoint,
         scheduler_config=SchedulerConfig(scheduler="StepLR", scheduler_params=None),
-        # pick species that is present in all models
-        labels=pd.DataFrame([{"filepath": "bird.mp4", "species_bird": 1}]),
+        labels=config.labels,
+        use_default_model_labels=config.use_default_model_labels,
     )
     assert model.hparams["scheduler"] == "StepLR"
 

--- a/tests/test_instantiate_model.py
+++ b/tests/test_instantiate_model.py
@@ -117,22 +117,16 @@ def test_not_use_default_model_labels(dummy_trained_model_checkpoint):
 
 
 @pytest.mark.parametrize("model", ["time_distributed", "slowfast", "european", "blank_nonblank"])
-def test_head_replaced_for_new_species(
-    labels_absolute_path, dummy_trained_model_checkpoint, model, tmp_path
-):
+def test_head_replaced_for_new_species(labels_absolute_path, model, tmp_path):
     """Tests that training a model using labels that are a not subset of the model species
     finetunes the model and replaces the model head."""
-    original_model = DummyZambaVideoClassificationLightningModule.from_disk(
-        dummy_trained_model_checkpoint
-    )
-
     labels = pd.read_csv(labels_absolute_path)
     # pick species that is not present in any models
     labels["label"] = "kangaroo"
 
     config = TrainConfig(
         labels=labels,
-        checkpoint=dummy_trained_model_checkpoint,
+        model_name=model,
         skip_load_validation=True,
         save_dir=tmp_path / "my_model",
     )
@@ -143,10 +137,7 @@ def test_head_replaced_for_new_species(
         use_default_model_labels=config.use_default_model_labels,
     )
 
-    assert (model.head.weight != original_model.head.weight).all()
     assert model.hparams["species"] == model.species == ["kangaroo"]
-    assert model.species == ["kangaroo"]
-    assert model.head.out_features == 1
 
 
 @pytest.mark.parametrize("model", ["time_distributed", "slowfast", "european"])

--- a/tests/test_instantiate_model.py
+++ b/tests/test_instantiate_model.py
@@ -8,17 +8,15 @@ from zamba.models.model_manager import instantiate_model
 from conftest import DummyZambaVideoClassificationLightningModule
 
 
-def test_scheduler_ignored_for_prediction(dummy_checkpoint, tmp_path):
+def test_scheduler_ignored_for_prediction(dummy_checkpoint):
     """Tests whether we can instantiate a model for prediction and ignore scheduler config."""
     original_hyperparams = torch.load(dummy_checkpoint)["hyper_parameters"]
     assert original_hyperparams["scheduler"] is None
 
     model = instantiate_model(
         checkpoint=dummy_checkpoint,
-        weight_download_region="us",
         scheduler_config=SchedulerConfig(scheduler="StepLR", scheduler_params=None),
         labels=None,
-        model_cache_dir=tmp_path,
     )
     # since labels is None, we are predicting. as a result, hparams are not updated
     assert model.hparams["scheduler"] is None
@@ -26,14 +24,12 @@ def test_scheduler_ignored_for_prediction(dummy_checkpoint, tmp_path):
     # # in Train Config, which contains ModelParams, labels cannot be None
 
 
-def test_default_scheduler_used(time_distributed_checkpoint, tmp_path):
+def test_default_scheduler_used(time_distributed_checkpoint):
     """Tests instantiate model uses the default scheduler from the hparams on the model."""
     default_scheduler_passed_model = instantiate_model(
         checkpoint=time_distributed_checkpoint,
-        weight_download_region="us",
         scheduler_config="default",
         labels=pd.DataFrame([{"filepath": "gorilla.mp4", "species_gorilla": 1}]),
-        model_cache_dir=tmp_path,
     )
 
     # with "default" scheduler_config, hparams from training are used
@@ -43,14 +39,12 @@ def test_default_scheduler_used(time_distributed_checkpoint, tmp_path):
     )
 
 
-def test_scheduler_used_if_passed(time_distributed_checkpoint, tmp_path):
+def test_scheduler_used_if_passed(time_distributed_checkpoint):
     """Tests that scheduler config gets used and overrides scheduler on time distributed training."""
     scheduler_passed_model = instantiate_model(
         checkpoint=time_distributed_checkpoint,
-        weight_download_region="us",
         scheduler_config=SchedulerConfig(scheduler="StepLR"),
         labels=pd.DataFrame([{"filepath": "gorilla.mp4", "species_gorilla": 1}]),
-        model_cache_dir=tmp_path,
     )
 
     # hparams reflect user specified scheduler config
@@ -61,28 +55,24 @@ def test_scheduler_used_if_passed(time_distributed_checkpoint, tmp_path):
     # check scheduler params get used
     scheduler_params_passed_model = instantiate_model(
         checkpoint=time_distributed_checkpoint,
-        weight_download_region="us",
         scheduler_config=SchedulerConfig(scheduler="StepLR", scheduler_params={"gamma": 0.3}),
         labels=pd.DataFrame([{"filepath": "gorilla.mp4", "species_gorilla": 1}]),
-        model_cache_dir=tmp_path,
     )
     assert scheduler_params_passed_model.hparams["scheduler_params"] == {"gamma": 0.3}
 
 
-def test_remove_scheduler(time_distributed_checkpoint, tmp_path):
+def test_remove_scheduler(time_distributed_checkpoint):
     """Tests that a scheduler config with None values removes the scheduler on the model."""
     remove_scheduler_model = instantiate_model(
         checkpoint=time_distributed_checkpoint,
-        weight_download_region="us",
         scheduler_config=SchedulerConfig(scheduler=None),
         labels=pd.DataFrame([{"filepath": "gorilla.mp4", "species_gorilla": 1}]),
-        model_cache_dir=tmp_path,
     )
     # pretrained model has scheduler but this is overridden with SchedulerConfig
     assert remove_scheduler_model.hparams["scheduler"] is None
 
 
-def test_head_not_replaced_for_species_subset(dummy_trained_model_checkpoint, tmp_path):
+def test_head_not_replaced_for_species_subset(dummy_trained_model_checkpoint):
     """Tests that training a model using labels that are a subset of the model species resumes
     model training without replacing the model head."""
     original_model = DummyZambaVideoClassificationLightningModule.from_disk(
@@ -91,10 +81,9 @@ def test_head_not_replaced_for_species_subset(dummy_trained_model_checkpoint, tm
 
     model = instantiate_model(
         checkpoint=dummy_trained_model_checkpoint,
-        weight_download_region="us",
         scheduler_config="default",
         labels=pd.DataFrame([{"filepath": "gorilla.mp4", "species_gorilla": 1}]),
-        model_cache_dir=tmp_path,
+        use_default_model_labels=True,
     )
 
     assert (model.head.weight == original_model.head.weight).all()
@@ -106,7 +95,7 @@ def test_head_not_replaced_for_species_subset(dummy_trained_model_checkpoint, tm
     assert model.model[-1].out_features == 3
 
 
-def test_not_use_default_model_labels(dummy_trained_model_checkpoint, tmp_path):
+def test_not_use_default_model_labels(dummy_trained_model_checkpoint):
     """Tests that training a model using labels that are a subset of the model species but
     with use_default_model_labels=False replaces the model head."""
     original_model = DummyZambaVideoClassificationLightningModule.from_disk(
@@ -115,10 +104,8 @@ def test_not_use_default_model_labels(dummy_trained_model_checkpoint, tmp_path):
 
     model = instantiate_model(
         checkpoint=dummy_trained_model_checkpoint,
-        weight_download_region="us",
         scheduler_config="default",
         labels=pd.DataFrame([{"filepath": "gorilla.mp4", "species_gorilla": 1}]),
-        model_cache_dir=tmp_path,
         use_default_model_labels=False,
     )
 
@@ -129,7 +116,7 @@ def test_not_use_default_model_labels(dummy_trained_model_checkpoint, tmp_path):
     assert model.model[-1].out_features == 1
 
 
-def test_head_replaced_for_new_species(dummy_trained_model_checkpoint, tmp_path):
+def test_head_replaced_for_new_species(dummy_trained_model_checkpoint):
     """Tests that training a model using labels that are a not subset of the model species
     finetunes the model and replaces the model head."""
     original_model = DummyZambaVideoClassificationLightningModule.from_disk(
@@ -138,10 +125,8 @@ def test_head_replaced_for_new_species(dummy_trained_model_checkpoint, tmp_path)
 
     model = instantiate_model(
         checkpoint=dummy_trained_model_checkpoint,
-        weight_download_region="us",
         scheduler_config="default",
         labels=pd.DataFrame([{"filepath": "alien.mp4", "species_alien": 1}]),
-        model_cache_dir=tmp_path,
     )
 
     assert (model.head.weight != original_model.head.weight).all()
@@ -159,10 +144,8 @@ def test_finetune_new_labels(labels_absolute_path, model, tmp_path):
     )
     model = instantiate_model(
         checkpoint=config.checkpoint,
-        weight_download_region=config.weight_download_region,
         scheduler_config="default",
         labels=pd.DataFrame([{"filepath": "kangaroo.mp4", "species_kangaroo": 1}]),
-        model_cache_dir=tmp_path,
     )
     assert model.species == ["kangaroo"]
 
@@ -178,11 +161,9 @@ def test_resume_subset_labels(labels_absolute_path, model, tmp_path):
     )
     model = instantiate_model(
         checkpoint=config.checkpoint,
-        weight_download_region=config.weight_download_region,
         scheduler_config=SchedulerConfig(scheduler="StepLR", scheduler_params=None),
         # pick species that is present in all models
         labels=pd.DataFrame([{"filepath": "bird.mp4", "species_bird": 1}]),
-        model_cache_dir=tmp_path,
     )
     assert model.hparams["scheduler"] == "StepLR"
 

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -436,6 +436,32 @@ class TrainConfig(ZambaBaseModel):
         return values
 
     @root_validator(skip_on_failure=True)
+    def validate_provided_species_and_predict_all_zamba_species(cls, values):
+        """If the model species are the desired output, the labels file must contain
+        a subset of the model species.
+        """
+        if values["predict_all_zamba_species"]:
+
+            provided_species = values["labels"].label.unique()
+            model_species = get_checkpoint_hparams(values["checkpoint"])["species"]
+            is_subset = set(provided_species).issubset(model_species)
+
+            if not is_subset:
+                raise ValueError(
+                    f"""
+                Conflicting information between `predict_all_zamba_species=True` and the
+                species provided in labels file.
+
+                If you want your model to predict all the zamba species, make sure your
+                labels are a subset. The species in the labels file that are not 
+                in the model species are {np.setdiff1d(provided_species, model_species)}.
+
+                If you want your model to only predict the species in your labels file,
+                set `predict_all_zamba_species` to False.
+                """
+                )
+
+    @root_validator(skip_on_failure=True)
     def validate_filepaths_and_labels(cls, values):
         logger.info("Validating labels csv.")
         labels = (

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -365,7 +365,7 @@ class TrainConfig(ZambaBaseModel):
             starting with ImageNet weights for image-based models (time_distributed,
             european, and blank_nonblank) and Kinetics weights for video-based models
             (slowfast). Defaults to False.
-        predict_all_zamba_species (bool): Output the full set of default model labels rather
+        use_default_model_labels (bool): Output the full set of default model labels rather
             than just the species in the labels file. Only applies if the provided labels are
             a subset of the default model labels. Defaults to True. If set to False, will
             replace the model head for finetuning.
@@ -393,7 +393,7 @@ class TrainConfig(ZambaBaseModel):
     overwrite: bool = False
     skip_load_validation: bool = False
     from_scratch: bool = False
-    predict_all_zamba_species: Optional[bool] = True
+    use_default_model_labels: Optional[bool] = True
     model_cache_dir: Optional[Path] = None
 
     class Config:
@@ -500,11 +500,11 @@ class TrainConfig(ZambaBaseModel):
         return values
 
     @root_validator(skip_on_failure=True, pre=True)
-    def validate_provided_species_and_predict_all_zamba_species(cls, values):
+    def validate_provided_species_and_use_default_model_labels(cls, values):
         """If the model species are the desired output, the labels file must contain
         a subset of the model species.
         """
-        if "predict_all_zamba_species" in values.keys():
+        if "use_default_model_labels" in values.keys():
 
             labels_df = (
                 pd.read_csv(values["labels"])
@@ -522,13 +522,13 @@ class TrainConfig(ZambaBaseModel):
 
             if not is_subset:
                 raise ValueError(
-                    "Conflicting information between `predict_all_zamba_species=True` and the "
+                    "Conflicting information between `use_default_model_labels=True` and the "
                     "species provided in labels file. "
                     "If you want your model to predict all the zamba species, make sure your "
                     "labels are a subset. The species in the labels file that are not "
                     f"in the model species are {np.setdiff1d(provided_species, model_species)}. "
                     "If you want your model to only predict the species in your labels file, "
-                    "set `predict_all_zamba_species` to False."
+                    "set `use_default_model_labels` to False."
                 )
         return values
 

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -504,23 +504,25 @@ class TrainConfig(ZambaBaseModel):
         """If the model species are the desired output, the labels file must contain
         a subset of the model species.
         """
-        if "use_default_model_labels" in values.keys():
 
-            labels_df = (
-                pd.read_csv(values["labels"])
-                if not isinstance(values["labels"], pd.DataFrame)
-                else values["labels"]
-            )
+        labels_df = (
+            pd.read_csv(values["labels"])
+            if not isinstance(values["labels"], pd.DataFrame)
+            else values["labels"]
+        )
 
-            provided_species = labels_df.label.unique()
+        provided_species = labels_df.label.unique()
 
-            hparams_file = MODELS_DIRECTORY / f"{values['model_name']}/hparams.yaml"
-            with hparams_file.open() as f:
-                model_species = yaml.safe_load(f)["species"]
+        hparams_file = MODELS_DIRECTORY / f"{values['model_name']}/hparams.yaml"
+        with hparams_file.open() as f:
+            model_species = yaml.safe_load(f)["species"]
 
-            is_subset = set(provided_species).issubset(model_species)
+        is_subset = set(provided_species).issubset(model_species)
 
-            if not is_subset:
+        if not is_subset:
+
+            # if labels are not a subset, user cannot set use_default_model_labels to True
+            if values.get("use_default_model_labels"):
                 raise ValueError(
                     "Conflicting information between `use_default_model_labels=True` and the "
                     "species provided in labels file. "
@@ -530,6 +532,10 @@ class TrainConfig(ZambaBaseModel):
                     "If you want your model to only predict the species in your labels file, "
                     "set `use_default_model_labels` to False."
                 )
+
+            else:
+                values["use_default_model_labels"] = False
+
         return values
 
     @root_validator(skip_on_failure=True)

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -22,10 +22,11 @@ from zamba.data.video import VideoLoaderConfig
 from zamba.exceptions import ZambaFfmpegException
 from zamba.models.registry import available_models
 from zamba.models.utils import (
-    RegionEnum,
+    download_weights,
     get_checkpoint_hparams,
+    get_default_hparams,
     get_model_checkpoint_filename,
-    get_model_hparams,
+    RegionEnum,
 )
 from zamba.pytorch.transforms import zamba_image_model_transforms, slowfast_transforms
 from zamba.settings import SPLIT_SEED, VIDEO_SUFFIXES
@@ -175,6 +176,7 @@ def check_files_exist_and_load(
 def validate_model_name_and_checkpoint(cls, values):
     """Ensures a checkpoint file or model name is provided. If a model name is provided,
     looks up the corresponding public checkpoint file from the official configs.
+    Download the checkpoint if it does not yet exist.
     """
     checkpoint = values.get("checkpoint")
     model_name = values.get("model_name")
@@ -199,6 +201,15 @@ def validate_model_name_and_checkpoint(cls, values):
             cached_path = Path(values["model_cache_dir"]) / values["checkpoint"]
             if cached_path.exists():
                 values["checkpoint"] = cached_path
+
+            # download if checkpoint doesn't exist
+            if not values["checkpoint"].exists():
+                logger.info(f"Downloading weights for model to {values['model_cache_dir']}.")
+                values["checkpoint"] = download_weights(
+                    filename=str(values["checkpoint"]),
+                    weight_region=values["weight_download_region"],
+                    destination_dir=values["model_cache_dir"],
+                )
 
     return values
 
@@ -370,10 +381,11 @@ class TrainConfig(ZambaBaseModel):
             starting with ImageNet weights for image-based models (time_distributed,
             european, and blank_nonblank) and Kinetics weights for video-based models
             (slowfast). Defaults to False.
-        use_default_model_labels (bool): Output the full set of default model labels rather
-            than just the species in the labels file. Only applies if the provided labels are
-            a subset of the default model labels. Defaults to True. If set to False, will
-            replace the model head for finetuning.
+        use_default_model_labels (bool, optional): By default, output the full set of
+            default model labels rather than just the species in the labels file. Only
+            applies if the provided labels are a subset of the default model labels.
+            If set to False, will replace the model head for finetuning and output only
+            the species in the provided labels file.
         model_cache_dir (Path, optional): Cache directory where downloaded model weights
             will be saved. If None and the MODEL_CACHE_DIR environment variable is
             not set, uses your default cache directory. Defaults to None.
@@ -398,7 +410,7 @@ class TrainConfig(ZambaBaseModel):
     overwrite: bool = False
     skip_load_validation: bool = False
     from_scratch: bool = False
-    use_default_model_labels: Optional[bool] = True
+    use_default_model_labels: Optional[bool] = None
     model_cache_dir: Optional[Path] = None
 
     class Config:
@@ -504,27 +516,23 @@ class TrainConfig(ZambaBaseModel):
         )
         return values
 
-    @root_validator(skip_on_failure=True, pre=True)
+    @root_validator(skip_on_failure=True)
     def validate_provided_species_and_use_default_model_labels(cls, values):
         """If the model species are the desired output, the labels file must contain
         a subset of the model species.
         """
+        provided_species = set(values["labels"].label)
 
-        labels_df = (
-            pd.read_csv(values["labels"])
-            if not isinstance(values["labels"], pd.DataFrame)
-            else values["labels"]
-        )
-
-        provided_species = set(labels_df.label)
-        # get model if specified otherwise use default to look up model species
-        model = values["model_name"] if values.get("model_name") else ModelEnum.time_distributed
-        model_species = set(get_model_hparams(model)["species"])
+        # hparams on checkpoint supersede base model
+        if values["checkpoint"] is not None:
+            model_species = set(get_checkpoint_hparams(values["checkpoint"])["species"])
+        else:
+            model_species = set(get_default_hparams(values["model_name"])["species"])
 
         if not provided_species.issubset(model_species):
 
             # if labels are not a subset, user cannot set use_default_model_labels to True
-            if values.get("use_default_model_labels"):
+            if values["use_default_model_labels"]:
                 raise ValueError(
                     "Conflicting information between `use_default_model_labels=True` and the "
                     "species provided in labels file. "
@@ -537,6 +545,10 @@ class TrainConfig(ZambaBaseModel):
 
             else:
                 values["use_default_model_labels"] = False
+
+        # if labels are a subset, default to True if no value provided
+        elif values["use_default_model_labels"] is None:
+            values["use_default_model_labels"] = True
 
         return values
 

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -511,15 +511,13 @@ class TrainConfig(ZambaBaseModel):
             else values["labels"]
         )
 
-        provided_species = labels_df.label.unique()
+        provided_species = set(labels_df.label)
 
         hparams_file = MODELS_DIRECTORY / f"{values['model_name']}/hparams.yaml"
         with hparams_file.open() as f:
-            model_species = yaml.safe_load(f)["species"]
+            model_species = set(yaml.safe_load(f)["species"])
 
-        is_subset = set(provided_species).issubset(model_species)
-
-        if not is_subset:
+        if not provided_species.issubset(model_species):
 
             # if labels are not a subset, user cannot set use_default_model_labels to True
             if values.get("use_default_model_labels"):
@@ -528,7 +526,7 @@ class TrainConfig(ZambaBaseModel):
                     "species provided in labels file. "
                     "If you want your model to predict all the zamba species, make sure your "
                     "labels are a subset. The species in the labels file that are not "
-                    f"in the model species are {np.setdiff1d(provided_species, model_species)}. "
+                    f"in the model species are {provided_species - model_species}. "
                     "If you want your model to only predict the species in your labels file, "
                     "set `use_default_model_labels` to False."
                 )

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -436,41 +436,6 @@ class TrainConfig(ZambaBaseModel):
         return values
 
     @root_validator(skip_on_failure=True)
-    def validate_provided_species_and_predict_all_zamba_species(cls, values):
-        """If the model species are the desired output, the labels file must contain
-        a subset of the model species.
-        """
-        if values["predict_all_zamba_species"]:
-
-            labels_df = (
-                pd.read_csv(values["labels"])
-                if not isinstance(values["labels"], pd.DataFrame)
-                else values["labels"]
-            )
-
-            provided_species = labels_df["label"].unique()
-
-            hparams_file = MODELS_DIRECTORY / f"{values['model_name']}/hparams.yaml"
-            with hparams_file.open() as f:
-                model_species = yaml.safe_load(f)["species"]
-
-            is_subset = set(provided_species).issubset(model_species)
-
-            if not is_subset:
-                raise ValueError(
-                "Conflicting information between `predict_all_zamba_species=True` and the "
-                "species provided in labels file. "
-
-                "If you want your model to predict all the zamba species, make sure your "
-                "labels are a subset. The species in the labels file that are not "
-                f"in the model species are {np.setdiff1d(provided_species, model_species)}. "
-
-                "If you want your model to only predict the species in your labels file, "
-                "set `predict_all_zamba_species` to False."
-                )
-        return values
-
-    @root_validator(skip_on_failure=True)
     def validate_filepaths_and_labels(cls, values):
         logger.info("Validating labels csv.")
         labels = (
@@ -531,6 +496,35 @@ class TrainConfig(ZambaBaseModel):
             data_dir=values["data_dir"],
             skip_load_validation=values["skip_load_validation"],
         )
+        return values
+
+    @root_validator(skip_on_failure=True)
+    def validate_provided_species_and_predict_all_zamba_species(cls, values):
+        """If the model species are the desired output, the labels file must contain
+        a subset of the model species.
+        """
+        if values["predict_all_zamba_species"]:
+
+            provided_species = values["labels"].label.unique()
+
+            hparams_file = MODELS_DIRECTORY / f"{values['model_name']}/hparams.yaml"
+            with hparams_file.open() as f:
+                model_species = yaml.safe_load(f)["species"]
+
+            is_subset = set(provided_species).issubset(model_species)
+
+            if not is_subset:
+                raise ValueError(
+                "Conflicting information between `predict_all_zamba_species=True` and the "
+                "species provided in labels file. "
+
+                "If you want your model to predict all the zamba species, make sure your "
+                "labels are a subset. The species in the labels file that are not "
+                f"in the model species are {np.setdiff1d(provided_species, model_species)}. "
+
+                "If you want your model to only predict the species in your labels file, "
+                "set `predict_all_zamba_species` to False."
+                )
         return values
 
     @root_validator(skip_on_failure=True)

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -517,7 +517,9 @@ class TrainConfig(ZambaBaseModel):
         )
 
         provided_species = set(labels_df.label)
-        model_species = set(get_model_hparams(values["model_name"])["species"])
+        # get model if specified otherwise use default to look up model species
+        model = values["model_name"] if values.get("model_name") else ModelEnum.time_distributed
+        model_species = set(get_model_hparams(model)["species"])
 
         if not provided_species.issubset(model_species):
 

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -21,7 +21,12 @@ from zamba.data.metadata import create_site_specific_splits
 from zamba.data.video import VideoLoaderConfig
 from zamba.exceptions import ZambaFfmpegException
 from zamba.models.registry import available_models
-from zamba.models.utils import RegionEnum, get_checkpoint_hparams, get_model_checkpoint_filename
+from zamba.models.utils import (
+    RegionEnum,
+    get_checkpoint_hparams,
+    get_model_checkpoint_filename,
+    get_model_hparams,
+)
 from zamba.pytorch.transforms import zamba_image_model_transforms, slowfast_transforms
 from zamba.settings import SPLIT_SEED, VIDEO_SUFFIXES
 
@@ -512,10 +517,7 @@ class TrainConfig(ZambaBaseModel):
         )
 
         provided_species = set(labels_df.label)
-
-        hparams_file = MODELS_DIRECTORY / f"{values['model_name']}/hparams.yaml"
-        with hparams_file.open() as f:
-            model_species = set(yaml.safe_load(f)["species"])
+        model_species = set(get_model_hparams(values["model_name"])["species"])
 
         if not provided_species.issubset(model_species):
 

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -71,6 +71,13 @@ def instantiate_model(
     model_class = available_models[hparams["model_class"]]
     logger.info(f"Instantiating model: {model_class.__name__}")
 
+    # predicting
+    if labels is None:
+        # predict; load from checkpoint uses associated hparams
+        logger.info("Loading from checkpoint.")
+        model = model_class.load_from_checkpoint(checkpoint_path=checkpoint)
+        return model
+
     # get species from labels file
     species = labels.filter(regex=r"^species_").columns.tolist()
     species = [s.split("species_", 1)[1] for s in species]
@@ -86,13 +93,6 @@ def instantiate_model(
         hparams.update({"species": species})
         model = model_class(**hparams)
         log_schedulers(model)
-        return model
-
-    # predicting
-    if labels is None:
-        # predict; load from checkpoint uses associated hparams
-        logger.info("Loading from checkpoint.")
-        model = model_class.load_from_checkpoint(checkpoint_path=checkpoint)
         return model
 
     # determine if finetuning or resuming training

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -26,7 +26,7 @@ from zamba.models.config import (
     RegionEnum,
 )
 from zamba.models.registry import available_models
-from zamba.models.utils import download_weights, get_checkpoint_hparams
+from zamba.models.utils import download_weights, get_checkpoint_hparams, get_model_hparams
 from zamba.pytorch.finetuning import BackboneFinetuning
 from zamba.pytorch_lightning.utils import ZambaDataModule, ZambaVideoClassificationLightningModule
 
@@ -73,8 +73,7 @@ def instantiate_model(
     """
     if from_scratch:
         # get hparams from official model
-        with (MODELS_DIRECTORY / f"{model_name}/hparams.yaml").open() as f:
-            hparams = yaml.safe_load(f)
+        hparams = get_model_hparams(model)
 
     else:
         # download if checkpoint doesn't exist

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -108,7 +108,8 @@ def instantiate_model(
     if labels is None:
         # predict; load from checkpoint uses associated hparams
         logger.info("Loading from checkpoint.")
-        return model_class.load_from_checkpoint(checkpoint_path=checkpoint)
+        model = model_class.load_from_checkpoint(checkpoint_path=checkpoint)
+        return model
 
     ## determine if finetuning or resuming training
 

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -39,16 +39,16 @@ def instantiate_model(
     labels: Optional[pd.DataFrame],
     from_scratch: bool = False,
     model_name: Optional[ModelEnum] = None,
-    predict_all_zamba_species: bool = True,
+    use_default_model_labels: bool = True,
 ) -> ZambaVideoClassificationLightningModule:
     """Instantiates the model from a checkpoint and detects whether the model head should be replaced.
-    The model head is replaced if labels contain species that are not on the model or predict_all_zamba_species=False.
+    The model head is replaced if labels contain species that are not on the model or use_default_model_labels=False.
 
     Supports model instantiation for the following cases:
     - train from scratch (from_scratch=True)
     - finetune with new species (from_scratch=False, labels contains different species than model)
-    - finetune with a subset of zamba species and output only the species in the labels file (predict_all_zamba_species=False)
-    - finetune with a subset of zamba species but output all zamba species (predict_all_zamba_species=True)
+    - finetune with a subset of zamba species and output only the species in the labels file (use_default_model_labels=False)
+    - finetune with a subset of zamba species but output all zamba species (use_default_model_labels=True)
     - predict using pretrained model (labels=None)
 
     Args:
@@ -64,7 +64,7 @@ def instantiate_model(
             Defaults to False. Only used if labels is not None.
         model_name (ModelEnum, optional): Model name used to look up default hparams used for that model.
             Only relevant if training from scratch.
-        predict_all_zamba_species(bool): Whether the species outputted by the model should be all zamba species.
+        use_default_model_labels(bool): Whether the species outputted by the model should be all zamba species.
             If you want the model classes to only be the species in your labels file, set to False.
             Defaults to True. Only used if labels is not None.
 
@@ -121,7 +121,7 @@ def instantiate_model(
     is_subset = set(species).issubset(set(hparams["species"]))
 
     if is_subset:
-        if predict_all_zamba_species:
+        if use_default_model_labels:
             return resume_training(
                 scheduler_config=scheduler_config,
                 hparams=hparams,
@@ -144,7 +144,7 @@ def instantiate_model(
             )
 
     # without a subset, you will always get a new head
-    # the config validation prohibits setting predict_all_zamba_species to True without a subset
+    # the config validation prohibits setting use_default_model_labels to True without a subset
     else:
         logger.info(
             "Provided species do not fully overlap with Zamba species. Replacing model head and finetuning."
@@ -253,7 +253,7 @@ def train_model(
         labels=train_config.labels,
         from_scratch=train_config.from_scratch,
         model_name=train_config.model_name,
-        predict_all_zamba_species=train_config.predict_all_zamba_species,
+        use_default_model_labels=train_config.use_default_model_labels,
     )
 
     data_module = ZambaDataModule(

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -73,7 +73,7 @@ def instantiate_model(
     """
     if from_scratch:
         # get hparams from official model
-        hparams = get_model_hparams(model)
+        hparams = get_model_hparams(model_name)
 
     else:
         # download if checkpoint doesn't exist
@@ -185,14 +185,16 @@ def resume_training(
         hparams.update(scheduler_config.dict())
 
     model = model_class.load_from_checkpoint(checkpoint_path=checkpoint, **hparams)
+    model_species = hparams["species"]
 
     # add in remaining columns for species that are not present
-    for c in set(hparams["species"]).difference(set(species)):
+    for c in set(model_species).difference(set(species)):
         # labels are still OHE at this point
         labels[f"species_{c}"] = 0
 
-    # sort columns so columns on dataloader are the same as columns on model
-    labels.sort_index(axis=1, inplace=True)
+    # order the columns on dataloader so they are the same as the model
+    col_order = [f"species_{s}" for s in model_species]
+    labels = labels[col_order]
     log_schedulers(model)
     return model
 

--- a/zamba/models/publish_models.py
+++ b/zamba/models/publish_models.py
@@ -33,7 +33,7 @@ def get_model_only_params(full_configuration, subset="train_config"):
             "skip_load_validation",
             "from_scratch",
             "model_cache_dir",
-            "predict_all_zamba_species",
+            "use_default_model_labels",
         ]:
             config.pop(key)
 

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -10,6 +10,7 @@ import torch
 import yaml
 
 from zamba import MODELS_DIRECTORY
+from zamba.pytorch_lightning.utils import ZambaVideoClassificationLightningModule
 
 S3_BUCKET = "s3://drivendata-public-assets"
 
@@ -48,6 +49,16 @@ def get_model_checkpoint_filename(model_name):
     with config_file.open() as f:
         config_dict = yaml.safe_load(f)
     return Path(config_dict["public_checkpoint"])
+
+
+def get_model_hparams(model):
+    if isinstance(model, ZambaVideoClassificationLightningModule):
+        return model.hparams
+
+    else:
+        hparams_file = MODELS_DIRECTORY / model / "hparams.yaml"
+        with hparams_file.open() as f:
+            return yaml.safe_load(f)
 
 
 def get_checkpoint_hparams(checkpoint):

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -51,16 +51,13 @@ def get_model_checkpoint_filename(model_name):
     return Path(config_dict["public_checkpoint"])
 
 
-def get_model_hparams(model):
-    if isinstance(model, ZambaVideoClassificationLightningModule):
-        return model.hparams
+def get_default_hparams(model):
+    if isinstance(model, Enum):
+        model = model.value
 
-    else:
-        if isinstance(model, Enum):
-            model = model.value
-        hparams_file = MODELS_DIRECTORY / model / "hparams.yaml"
-        with hparams_file.open() as f:
-            return yaml.safe_load(f)
+    hparams_file = MODELS_DIRECTORY / model / "hparams.yaml"
+    with hparams_file.open() as f:
+        return yaml.safe_load(f)
 
 
 def get_checkpoint_hparams(checkpoint):

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -56,6 +56,8 @@ def get_model_hparams(model):
         return model.hparams
 
     else:
+        if isinstance(model, Enum):
+            model = model.value
         hparams_file = MODELS_DIRECTORY / model / "hparams.yaml"
         with hparams_file.open() as f:
             return yaml.safe_load(f)

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -10,7 +10,6 @@ import torch
 import yaml
 
 from zamba import MODELS_DIRECTORY
-from zamba.pytorch_lightning.utils import ZambaVideoClassificationLightningModule
 
 S3_BUCKET = "s3://drivendata-public-assets"
 


### PR DESCRIPTION
## Refactoring in `instantiate_model`
Refactors the logic in `instantiate_model` to branch on `is_subset` to be more explicit. The previous logic tried to group the cases for replacing the head vs. resuming training. 

```
# replace the head
elif not predict_all_zamba_species or not is_subset:
...
# resume training
elif is_subset:
...
```

This new code change should not change the behavior, but should be more readable. The branching structure is now:
```
if is_subset:
  if predict_all_zamba_species:
    resume_training()
  else:
    replace_head()

else:
  replace_head()
```

## Validation for `is_subset` and `predict_all_zamba_species`
This also allows us to enforce that `is_subset` (based on the model species and the labels species) is in agreement with `predict_all_zamba_species`. Notes:
- `predict_all_zamba_species` is True by default. We assume that if you're finetuning on a subset of data, you still want all the zamba species. If you don't want this (e.g. you want duikers, elephants, and blanks only), you need to set this to False. This behavior is the same as before.
- We now only validate `predict_all_zamba_species` if you set a value (we make this field an optional boolean and use a pre validator).
- If you provide labels that are not a subset (e.g. cats and dogs) and do not specify `predict_all_zamba_labels`, we'll set predict_all_zamba_labels to False for you since your only option is a new head with a subset. This is the same result as before, where providing a subset yielded a new head. The difference is that before you could have set conflicting values, but not being a subset would have superseded the predict_all_zamba_labels field.

## Additional changes
- renames `predict_all_zamba_species` to `use_default_model_classes` to apply to the blank nonblank model as well
- fixes some copy pasta errors in the train tutorial

Outstanding:
- [x] add test for new validator

Closes #212 
Closes https://github.com/drivendataorg/pjmf-zamba/issues/130