### PR TITLE
Set up correct OHE labels for subsets that use default model labels

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,7 +117,11 @@ def test_extra_column(tmp_path, labels_absolute_path):
         index=False,
     )
     # this column is not one hot encoded
-    config = TrainConfig(labels=tmp_path / "extra_species_col.csv", save_dir=tmp_path / "my_model")
+    config = TrainConfig(
+        labels=tmp_path / "extra_species_col.csv",
+        save_dir=tmp_path / "my_model",
+        use_default_model_labels=False,
+    )
     assert list(config.labels.columns) == [
         "filepath",
         "split",

--- a/tests/test_instantiate_model.py
+++ b/tests/test_instantiate_model.py
@@ -4,7 +4,7 @@ import torch
 
 from zamba.models.config import SchedulerConfig, TrainConfig
 from zamba.models.model_manager import instantiate_model
-from zamba.models.utils import get_default_hparams
+from zamba.models.utils import get_model_species
 
 from conftest import DummyZambaVideoClassificationLightningModule
 
@@ -162,4 +162,4 @@ def test_resume_subset_labels(labels_absolute_path, model_name, tmp_path):
         use_default_model_labels=config.use_default_model_labels,
     )
     assert model.hparams["scheduler"] == "StepLR"
-    assert model.species == get_default_hparams(model_name)["species"]
+    assert model.species == get_model_species(checkpoint=None, model_name=model_name)

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -567,6 +567,16 @@ class TrainConfig(ZambaBaseModel):
         # lowercase to facilitate subset checking
         labels["label"] = labels.label.str.lower()
 
+        # TODO: fix replicated code
+        if values["checkpoint"] is not None:
+            model_species = set(get_checkpoint_hparams(values["checkpoint"])["species"])
+        else:
+            model_species = set(get_default_hparams(values["model_name"])["species"])
+
+        labels["label"] = pd.Categorical(
+            labels.label, categories=model_species if values["use_default_model_labels"] else None
+        )
+
         # one hot encode collapse to one row per video
         labels = (
             pd.get_dummies(labels.rename(columns={"label": "species"}), columns=["species"])

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -633,7 +633,7 @@ def make_split(labels, values):
         too_few = {
             k.split("species_", 1)[1]: v
             for k, v in num_videos_per_species.items()
-            if v < len(expected_splits)
+            if 0 < v < len(expected_splits)
         }
 
         if len(too_few) > 0:
@@ -644,12 +644,14 @@ def make_split(labels, values):
         for c in labels.filter(regex="species_").columns:
             species_df = labels[labels[c] > 0]
 
-            # within each species, seed splits by putting one video in each set and then allocate videos based on split proportions
-            labels.loc[species_df.index, "split"] = expected_splits + random.choices(
-                list(values["split_proportions"].keys()),
-                weights=list(values["split_proportions"].values()),
-                k=len(species_df) - len(expected_splits),
-            )
+            if len(species_df):
+
+                # within each species, seed splits by putting one video in each set and then allocate videos based on split proportions
+                labels.loc[species_df.index, "split"] = expected_splits + random.choices(
+                    list(values["split_proportions"].keys()),
+                    weights=list(values["split_proportions"].values()),
+                    k=len(species_df) - len(expected_splits),
+                )
 
         logger.info(f"{labels.split.value_counts()}")
 

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -24,7 +24,6 @@ from zamba.models.registry import available_models
 from zamba.models.utils import (
     download_weights,
     get_checkpoint_hparams,
-    get_default_hparams,
     get_model_checkpoint_filename,
     get_model_species,
     RegionEnum,

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -166,16 +166,6 @@ def resume_training(
         hparams.update(scheduler_config.dict())
 
     model = model_class.load_from_checkpoint(checkpoint_path=checkpoint, **hparams)
-    model_species = hparams["species"]
-
-    # add in remaining columns for species that are not present
-    for c in set(model_species).difference(set(species)):
-        # labels are still OHE at this point
-        labels[f"species_{c}"] = 0
-
-    # order the columns on dataloader so they are the same as the model
-    col_order = [f"species_{s}" for s in model_species]
-    labels = labels[col_order]
     log_schedulers(model)
     return model
 

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -73,6 +73,5 @@ def get_model_species(checkpoint, model_name):
     if checkpoint is not None:
         model_species = get_checkpoint_hparams(checkpoint)["species"]
     else:
-        # get default model name if not specified
         model_species = get_default_hparams(model_name)["species"]
     return model_species

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -66,3 +66,13 @@ def get_checkpoint_hparams(checkpoint):
 @lru_cache()
 def _cached_hparams(checkpoint):
     return torch.load(checkpoint, map_location=torch.device("cpu"))["hyper_parameters"]
+
+
+def get_model_species(checkpoint, model_name):
+    # hparams on checkpoint supersede base model
+    if checkpoint is not None:
+        model_species = get_checkpoint_hparams(checkpoint)["species"]
+    else:
+        # get default model name if not specified
+        model_species = get_default_hparams(model_name)["species"]
+    return model_species


### PR DESCRIPTION
Fixes #234 

#229 introduced a bug whereby the new columns added to the labels file were in a different order than what is on the model. This PR fixes that by setting up the correct one hot encoded labels in the `preprocess_labels` validator rather than `instantiate_model`. Using the `use_default_model_labels`, we know whether the labels file should contain columns (with all zeroes) for species that are not present in the labels but are on the base model. Using a pd.Categorical before `get_dummies` allows us to generate these columns.

Running `zamba train --config tests/assets/sample_train_config.yaml` now works; the labels file has three species present in zamba but trains a model that outputs the full set of 32 labels.