### PR TITLE
Don't show local variables in exceptions and errors

### DIFF
--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -21,7 +21,7 @@ from zamba.models.utils import RegionEnum
 from zamba.version import __version__
 
 
-app = typer.Typer(pretty_exceptions_enable=False)
+app = typer.Typer(pretty_exceptions_show_locals=False)
 
 
 @app.command()

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -21,7 +21,7 @@ from zamba.models.utils import RegionEnum
 from zamba.version import __version__
 
 
-app = typer.Typer()
+app = typer.Typer(pretty_exceptions_enable=False)
 
 
 @app.command()


### PR DESCRIPTION
Fixes #233 

Relevant part of typer docs explaining exception and error handling: https://typer.tiangolo.com/tutorial/exceptions/

We can turn off the `rich` behavior entirely, but I propose just turning off the "show local variables" behavior. This way, we still get a more nicely colored stack trace, but with the same amount of info as before. 

Below is a screenshot from the example case, showing the new behavior:
<img width="953" alt="image" src="https://user-images.githubusercontent.com/22667367/192615918-f56f4ed5-7a6b-4d74-b41c-756668852b89.png">
