### PR TITLE
Change DDPPlugin to DDPStrategy

### DIFF
--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -323,13 +323,17 @@ def train_model(
     if not train_config.dry_run:
         if trainer.datamodule.test_dataloader() is not None:
             logger.info("Calculating metrics on holdout set.")
-            test_metrics = trainer.test(dataloaders=trainer.datamodule.test_dataloader())[0]
+            test_metrics = trainer.test(
+                dataloaders=trainer.datamodule.test_dataloader(), ckpt_path="best"
+            )[0]
             with (Path(logging_and_save_dir) / "test_metrics.json").open("w") as fp:
                 json.dump(test_metrics, fp, indent=2)
 
         if trainer.datamodule.val_dataloader() is not None:
             logger.info("Calculating metrics on validation set.")
-            val_metrics = trainer.validate(dataloaders=trainer.datamodule.val_dataloader())[0]
+            val_metrics = trainer.validate(
+                dataloaders=trainer.datamodule.val_dataloader(), ckpt_path="best"
+            )[0]
             with (Path(logging_and_save_dir) / "val_metrics.json").open("w") as fp:
                 json.dump(val_metrics, fp, indent=2)
 

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
-from pytorch_lightning.plugins import DDPPlugin
+from pytorch_lightning.strategies import DDPStrategy
 
 from zamba.data.video import VideoLoaderConfig
 from zamba.models.config import (
@@ -281,7 +281,7 @@ def train_model(
         logger=tensorboard_logger,
         callbacks=callbacks,
         fast_dev_run=train_config.dry_run,
-        strategy=DDPPlugin(find_unused_parameters=False)
+        strategy=DDPStrategy(find_unused_parameters=False)
         if data_module.multiprocessing_context is not None
         else None,
     )

--- a/zamba/pytorch_lightning/utils.py
+++ b/zamba/pytorch_lightning/utils.py
@@ -200,7 +200,11 @@ class ZambaVideoClassificationLightningModule(LightningModule):
     def compute_and_log_metrics(
         self, y_true: np.ndarray, y_pred: np.ndarray, y_proba: np.ndarray, subset: str
     ):
-        self.log(f"{subset}_macro_f1", f1_score(y_true, y_pred, average="macro", zero_division=0))
+        self.log(
+            f"{subset}_macro_f1",
+            f1_score(y_true, y_pred, average="macro", zero_division=0),
+            sync_dist=True,
+        )
 
         # if only two classes, skip top_k accuracy since not enough classes
         if self.num_classes > 2:
@@ -216,9 +220,10 @@ class ZambaVideoClassificationLightningModule(LightningModule):
                             labels=np.arange(y_proba.shape[1]),
                             k=k,
                         ),
+                        sync_dist=True,
                     )
         else:
-            self.log(f"{subset}_accuracy", accuracy_score(y_true, y_pred))
+            self.log(f"{subset}_accuracy", accuracy_score(y_true, y_pred), sync_dist=True)
 
         for metric_name, label, metric in compute_species_specific_metrics(
             y_true, y_pred, self.species

--- a/zamba/pytorch_lightning/utils.py
+++ b/zamba/pytorch_lightning/utils.py
@@ -203,7 +203,6 @@ class ZambaVideoClassificationLightningModule(LightningModule):
         self.log(
             f"{subset}_macro_f1",
             f1_score(y_true, y_pred, average="macro", zero_division=0),
-            sync_dist=True,
         )
 
         # if only two classes, skip top_k accuracy since not enough classes
@@ -220,10 +219,9 @@ class ZambaVideoClassificationLightningModule(LightningModule):
                             labels=np.arange(y_proba.shape[1]),
                             k=k,
                         ),
-                        sync_dist=True,
                     )
         else:
-            self.log(f"{subset}_accuracy", accuracy_score(y_true, y_pred), sync_dist=True)
+            self.log(f"{subset}_accuracy", accuracy_score(y_true, y_pred))
 
         for metric_name, label, metric in compute_species_specific_metrics(
             y_true, y_pred, self.species


### PR DESCRIPTION
`DDPPlugin` was deprecated in pytorch lightning [1.8](https://github.com/Lightning-AI/lightning/releases) which came out today. Replace with supported `DDPStrategy`. We don't pin PTL, so we are subject to deprecated code in new releases.

Bonus fix:
- address checkpoint warning
```
2022-11-01 19:42:05.757 | INFO     | zamba.models.model_manager:train_model:331 - Calculating metrics on validation set.
/usr/local/lib/python3.8/dist-packages/pytorch_lightning/trainer/connectors/checkpoint_connector.py:129: UserWarning: `.validate(ckpt_path=None)` was called without a model. The best model of the previous `fit` call will be used. You can pass `.validate(ckpt_path='best')` to use the best model or `.validate(ckpt_path='last')` to use the last model. If you pass a value, this warning will be silenced.
```