### PR TITLE
Interpret empty `VIDEO_CACHE_DIR` as None

### DIFF
--- a/tests/test_load_video_frames.py
+++ b/tests/test_load_video_frames.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pytest
 import shutil
 import subprocess
@@ -583,3 +584,14 @@ def test_caching(tmp_path, caplog, train_metadata):
     ).__getitem__(index=0)[0]
 
     assert np.array_equal(no_config, config_with_nones)
+
+
+def test_validate_video_cache_dir():
+    with mock.patch.dict(os.environ, {"VIDEO_CACHE_DIR": "example_cache_dir"}):
+        config = VideoLoaderConfig()
+        assert config.cache_dir == Path("example_cache_dir")
+
+    for cache in ["", 0]:
+        with mock.patch.dict(os.environ, {"VIDEO_CACHE_DIR": str(cache)}):
+            config = VideoLoaderConfig()
+            assert config.cache_dir is None

--- a/zamba/data/video.py
+++ b/zamba/data/video.py
@@ -220,6 +220,9 @@ class VideoLoaderConfig(BaseModel):
         if cache_dir is None:
             cache_dir = os.getenv("VIDEO_CACHE_DIR", None)
 
+            if cache_dir in ["", "0"]:
+                cache_dir = None
+
         if cache_dir is not None:
             cache_dir = Path(cache_dir)
             cache_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
If `VIDEO_CACHE_DIR` gets set to an empty string or 0, it will be interpreted as True for caching. This PR adds logic so that empty strings or 0s in the environment variable will be interpreted as no caching is desired.