### PR TITLE
Add depth module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           make densepose-tests
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Now you can pass this configuration to the command line. See the [Quickstart](ht
 
 You can then share your model with others by adding it to the [Model Zoo Wiki](https://github.com/drivendataorg/zamba/wiki).
 
-### Estimating distance
+### Estimating distance between animals and the camera
 
 ```console
 $ zamba depth --data-dir path/to/videos

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once you have `zamba` installed, some good starting points are:
 
 Once `zamba` is installed, you can see the basic command options with:
 ```console
-❯ zamba --help
+$ zamba --help
 
  Usage: zamba [OPTIONS] COMMAND [ARGS]...
 
@@ -108,6 +108,16 @@ predict_config:
 Now you can pass this configuration to the command line. See the [Quickstart](https://zamba.drivendata.org/docs/stable/quickstart/) page or the user tutorial on [training a model](https://zamba.drivendata.org/docs/stable/train-tutorial/) for more details.
 
 You can then share your model with others by adding it to the [Model Zoo Wiki](https://github.com/drivendataorg/zamba/wiki).
+
+### Estimating distance
+
+```console
+$ zamba depth --data-dir path/to/videos
+```
+
+By default, predictions will be saved to `depth_predictions.csv`. Run `zamba depth --help` to list all possible options to pass to `depth`.
+
+See the [depth estimation page](https://zamba.drivendata.org/docs/stable/models/depth/) for more details.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://user-images.githubusercontent.com/46792169/138346340-98ee196a-5ecd-4753-
 - Identify which species appear in each video
 - Filter out blank videos
 - Create your own custom models that identify your species in your habitats
+- Estimate the distance between animals in the frame and the camera
 - And more! 🙈 🙉 🙊
 
 The official models in `zamba` can identify blank videos (where no animal is present) along with 32 species common to Africa and 11 species common to Europe. Users can also finetune models using their own labeled videos to then make predictions for new species and/or new ecologies.
@@ -49,24 +50,27 @@ Once you have `zamba` installed, some good starting points are:
 
 Once `zamba` is installed, you can see the basic command options with:
 ```console
-$ zamba --help
-Usage: zamba [OPTIONS] COMMAND [ARGS]...
+❯ zamba --help
 
-  Zamba is a tool built in Python to automatically identify the species seen
-  in camera trap videos from sites in Africa and Europe. Visit
-  https://zamba.drivendata.org/docs for more in-depth documentation.
+ Usage: zamba [OPTIONS] COMMAND [ARGS]...
 
-Options:
-  --version             Show zamba version and exit.
-  --install-completion  Install completion for the current shell.
-  --show-completion     Show completion for the current shell, to copy it or
-                        customize the installation.
-  --help                Show this message and exit.
+ Zamba is a tool built in Python to automatically identify the species seen in camera trap
+ videos from sites in Africa and Europe. Visit https://zamba.drivendata.org/docs for more
+ in-depth documentation.
 
-Commands:
-  densepose  Run densepose algorithm on videos.
-  predict    Identify species in a video.
-  train      Train a model on your labeled data.
+╭─ Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --version                     Show zamba version and exit.                                │
+│ --install-completion          Install completion for the current shell.                   │
+│ --show-completion             Show completion for the current shell, to copy it or        │
+│                               customize the installation.                                 │
+│ --help                        Show this message and exit.                                 │
+╰───────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ────────────────────────────────────────────────────────────────────────────────╮
+│ densepose      Run densepose algorithm on videos.                                         │
+│ depth          Estimate animal distance at each second in the video.                      │
+│ predict        Identify species in a video.                                               │
+│ train          Train a model on your labeled data.                                        │
+╰───────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 `zamba` can be used "out of the box" to generate predictions or train a model using your own videos. `zamba` supports the same video formats as FFmpeg, [which are listed here](https://www.ffmpeg.org/general.html#Supported-File-Formats_002c-Codecs-or-Features). Any videos that fail a set of FFmpeg checks will be skipped during inference or training.

--- a/docs/docs/api-reference/depth_config.md
+++ b/docs/docs/api-reference/depth_config.md
@@ -1,0 +1,3 @@
+# zamba.models.depth_estimation.config
+
+::: zamba.models.depth_estimation.config

--- a/docs/docs/api-reference/depth_manager.md
+++ b/docs/docs/api-reference/depth_manager.md
@@ -1,0 +1,3 @@
+# zamba.models.depth_estimation.depth_manager
+
+::: zamba.models.depth_estimation.depth_manager

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -109,6 +109,16 @@ Now you can pass this configuration to the command line. See the [Quickstart](qu
 
 You can then share your model with others by adding it to the [Model Zoo Wiki](https://github.com/drivendataorg/zamba/wiki).
 
+### Estimating distance
+
+```console
+$ zamba depth --data-dir path/to/videos
+```
+
+By default, predictions will be saved to `depth_predictions.csv`. Run `zamba depth --help` to list all possible options to pass to `depth`.
+
+See the [Quickstart](quickstart/) page or the user tutorial on [classifying videos](predict-tutorial/) for more details.
+
 
 ## Contributing
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,6 +14,7 @@
 - Identify which species appear in each video
 - Filter out blank videos
 - Create your own custom models that identify your species in your habitats
+- Estimate the distance between animals in the frame and the camera
 - And more! 🙈 🙉 🙊
 
 The official models in `zamba` can identify blank videos (where no animal is present) along with 32 species common to Africa and 11 species common to Europe. Users can also finetune models using their own labeled videos to then make predictions for new species and/or new ecologies.
@@ -49,24 +50,27 @@ Once you have `zamba` installed, some good starting points are:
 
 Once `zamba` is installed, you can see the basic command options with:
 ```console
-$ zamba --help
-Usage: zamba [OPTIONS] COMMAND [ARGS]...
+❯ zamba --help
 
-  Zamba is a tool built in Python to automatically identify the species seen
-  in camera trap videos from sites in Africa and Europe. Visit
-  https://zamba.drivendata.org/docs for more in-depth documentation.
+ Usage: zamba [OPTIONS] COMMAND [ARGS]...
 
-Options:
-  --version             Show zamba version and exit.
-  --install-completion  Install completion for the current shell.
-  --show-completion     Show completion for the current shell, to copy it or
-                        customize the installation.
-  --help                Show this message and exit.
+ Zamba is a tool built in Python to automatically identify the species seen in camera trap
+ videos from sites in Africa and Europe. Visit https://zamba.drivendata.org/docs for more
+ in-depth documentation.
 
-Commands:
-  densepose  Run densepose algorithm on videos.
-  predict    Identify species in a video.
-  train      Train a model on your labeled data.
+╭─ Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --version                     Show zamba version and exit.                                │
+│ --install-completion          Install completion for the current shell.                   │
+│ --show-completion             Show completion for the current shell, to copy it or        │
+│                               customize the installation.                                 │
+│ --help                        Show this message and exit.                                 │
+╰───────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ────────────────────────────────────────────────────────────────────────────────╮
+│ densepose      Run densepose algorithm on videos.                                         │
+│ depth          Estimate animal distance at each second in the video.                      │
+│ predict        Identify species in a video.                                               │
+│ train          Train a model on your labeled data.                                        │
+╰───────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 `zamba` can be used "out of the box" to generate predictions or train a model using your own videos. `zamba` supports the same video formats as FFmpeg, [which are listed here](https://www.ffmpeg.org/general.html#Supported-File-Formats_002c-Codecs-or-Features). Any videos that fail a set of FFmpeg checks will be skipped during inference or training.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -50,7 +50,7 @@ Once you have `zamba` installed, some good starting points are:
 
 Once `zamba` is installed, you can see the basic command options with:
 ```console
-❯ zamba --help
+$ zamba --help
 
  Usage: zamba [OPTIONS] COMMAND [ARGS]...
 
@@ -109,7 +109,7 @@ Now you can pass this configuration to the command line. See the [Quickstart](qu
 
 You can then share your model with others by adding it to the [Model Zoo Wiki](https://github.com/drivendataorg/zamba/wiki).
 
-### Estimating distance
+### Estimating distance between animals and the camera
 
 ```console
 $ zamba depth --data-dir path/to/videos
@@ -117,7 +117,7 @@ $ zamba depth --data-dir path/to/videos
 
 By default, predictions will be saved to `depth_predictions.csv`. Run `zamba depth --help` to list all possible options to pass to `depth`.
 
-See the [Quickstart](quickstart/) page or the user tutorial on [classifying videos](predict-tutorial/) for more details.
+See the [depth estimation page](models/depth/) for more details.
 
 
 ## Contributing

--- a/docs/docs/models/depth.md
+++ b/docs/docs/models/depth.md
@@ -56,7 +56,7 @@ Here's how to run the depth estimation model.
 
 ### Debugging
 
-Unlike in the species classification models, selected frames are stored in memory rather than cached to disk. If you run out of memory, try running on a smaller number of videos. If you hit a GPU memory error, try reducing the [number of workers](../../debugging/#reducing-num_workers) or the [batch size](../../debugging/#reducing-the-batch-size).
+Unlike in the species classification models, selected frames are stored in memory rather than cached to disk. If you run out of memory, try predicting on a smaller number of videos. If you hit a GPU memory error, try reducing the [number of workers](../../debugging/#reducing-num_workers) or the [batch size](../../debugging/#reducing-the-batch-size).
 
 ## Getting help
 

--- a/docs/docs/models/depth.md
+++ b/docs/docs/models/depth.md
@@ -1,0 +1,94 @@
+# Depth estimation
+
+## Background
+
+The depth estimation model is one of the winning models from the [Deep Chimpact: Depth Estimation for Wildlife Conservation](https://www.drivendata.org/competitions/82/competition-wildlife-video-depth-estimation/) machine learning challenge hosted by DrivenData. 
+
+The goal of this challenge was to use machine learning and advances in monocular (single-lens) depth estimation techniques to automatically estimate the distance between a camera trap and an animal contained in its video footage. The challenge drew on a unique labeled dataset from research teams from the Max Planck Institute for Evolutionary Anthropology (MPI-EVA) and the Wild Chimpanzee Foundation (WCF).
+
+The Zamba package supports running the depth estimation model on videos. Under the hood, it does the following:
+
+- Resamples the video to one frame per second
+- Runs the [MegadetectorLite](models/species-detection.md#megadetectorlite) model on each frame to find frames with animals in them
+- Estimates depth for each detected animal in the frame
+- Outputs a csv with predictions
+
+## Output format
+
+The output of the depth estimation model is a csv with the following columns:
+
+- `filepath`: video name
+- `time`: seconds from the start of the video
+- `distance`: distance between detected animal and the camera
+
+There will be multiple rows per timestamp if there are multiple animals detected in the frame. If there is no animal in the frame, the distance will be null.
+
+For example, the first few rows of the `depth_predictions.csv` might look like this:
+
+```
+filepath,time,distance
+video_1.avi,0,7.3504286
+video_1.avi,0,7.3504286
+video_1.avi,1,
+video_1.avi,2,
+video_1.avi,3,
+```
+
+## Installation
+
+The depth estimation is included by default. If you've already [installed zamba](/docs/install/), there's nothing more you need to do.
+
+## Running depth estimation
+
+Here's how to run the depth estimation model.
+
+=== "CLI"
+    ```bash
+    # output a csv with depth predictions for each frame in the videos in PATH_TO_VIDEOS
+    zamba depth --data-dir PATH_TO_VIDEOS
+    ```
+=== "Python"
+    ```python
+    from zamba.models.depth_estimation import DepthEstimationConfig
+    depth_conf = DepthEstimationConfig(data_dir="PATH_TO_VIDEOS")
+    depth_conf.run_model()
+    ```
+
+## Getting help
+
+To see all of the available options, run `zamba depth --help`.
+
+```console
+$ zamba depth --help
+
+ Usage: zamba depth [OPTIONS]
+
+ Run depth estimation algorithm on frames in which animals are detected.
+
+╭─ Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --filepaths                       PATH          Path to csv containing `filepath` column  │
+│                                                 with videos.                              │
+│                                                 [default: None]                           │
+│ --data-dir                        PATH          Path to folder containing videos.         │
+│                                                 [default: None]                           │
+│ --save-to                         PATH          An optional directory or csv path for     │
+│                                                 saving the output. Defaults to            │
+│                                                 `depth_predictions.csv` in the working    │
+│                                                 directory.                                │
+│                                                 [default: None]                           │
+│ --overwrite               -o                    Overwrite output csv if it exists.        │
+│ --batch-size                      INTEGER       Batch size to use for inference.          │
+│                                                 [default: None]                           │
+│ --model-cache-dir                 PATH          Path to directory for downloading model   │
+│                                                 weights. Alternatively, specify with      │
+│                                                 environment variable `MODEL_CACHE_DIR`.   │
+│                                                 If not specified, user's cache directory  │
+│                                                 is used.                                  │
+│                                                 [default: None]                           │
+│ --weight-download-region          [us|eu|asia]  Server region for downloading weights.    │
+│                                                 [default: None]                           │
+│ --yes                     -y                    Skip confirmation of configuration and    │
+│                                                 proceed right to prediction.              │
+│ --help                                          Show this message and exit.               │
+╰───────────────────────────────────────────────────────────────────────────────────────────╯
+```

--- a/docs/docs/models/depth.md
+++ b/docs/docs/models/depth.md
@@ -27,8 +27,8 @@ For example, the first few rows of the `depth_predictions.csv` might look like t
 
 ```
 filepath,time,distance
-video_1.avi,0,7.3504286
-video_1.avi,0,7.3504286
+video_1.avi,0,7.4
+video_1.avi,0,7.4
 video_1.avi,1,
 video_1.avi,2,
 video_1.avi,3,

--- a/docs/docs/models/depth.md
+++ b/docs/docs/models/depth.md
@@ -2,9 +2,9 @@
 
 ## Background
 
-Our depth estimation model is useful for predicting the distance an animal is from the camera, which is an input into models used to estimate animal abundance. The depth model comes from one of the winners of the [Deep Chimpact: Depth Estimation for Wildlife Conservation](https://www.drivendata.org/competitions/82/competition-wildlife-video-depth-estimation/) machine learning challenge hosted by DrivenData.
+Our depth estimation model is useful for predicting the distance an animal is from the camera, which is an input into models used to estimate animal abundance. 
 
-The goal of this challenge was to use machine learning and advances in monocular (single-lens) depth estimation techniques to automatically estimate the distance between a camera trap and an animal contained in its video footage. The challenge drew on a unique labeled dataset from research teams from the Max Planck Institute for Evolutionary Anthropology (MPI-EVA) and the Wild Chimpanzee Foundation (WCF).
+The depth model comes from one of the winners of the [Deep Chimpact: Depth Estimation for Wildlife Conservation](https://www.drivendata.org/competitions/82/competition-wildlife-video-depth-estimation/) machine learning challenge hosted by DrivenData. The goal of this challenge was to use machine learning and advances in monocular (single-lens) depth estimation techniques to automatically estimate the distance between a camera trap and an animal contained in its video footage. The challenge drew on a unique labeled dataset from research teams from the Max Planck Institute for Evolutionary Anthropology (MPI-EVA) and the Wild Chimpanzee Foundation (WCF).
 
 The Zamba package supports running the depth estimation model on videos. Under the hood, it does the following:
 

--- a/docs/docs/models/depth.md
+++ b/docs/docs/models/depth.md
@@ -9,7 +9,7 @@ The depth model comes from one of the winners of the [Deep Chimpact: Depth Estim
 The Zamba package supports running the depth estimation model on videos. Under the hood, it does the following:
 
 - Resamples the video to one frame per second
-- Runs the [MegadetectorLite](models/species-detection.md#megadetectorlite) model on each frame to find frames with animals in them
+- Runs the [MegadetectorLite](../models/species-detection.md#megadetectorlite) model on each frame to find frames with animals in them
 - Estimates depth for each detected animal in the frame
 - Outputs a csv with predictions
 
@@ -53,6 +53,10 @@ Here's how to run the depth estimation model.
     depth_conf = DepthEstimationConfig(data_dir="PATH_TO_VIDEOS")
     depth_conf.run_model()
     ```
+
+### Debugging
+
+Unlike in the species classification models, selected frames are stored in memory rather than cached to disk. If you run out of memory, try running on a smaller number of videos. If you hit a GPU memory error, try reducing the [number of workers](../../debugging/#reducing-num_workers) or the [batch size](../../debugging/#reducing-the-batch-size).
 
 ## Getting help
 

--- a/docs/docs/models/depth.md
+++ b/docs/docs/models/depth.md
@@ -63,7 +63,7 @@ $ zamba depth --help
 
  Usage: zamba depth [OPTIONS]
 
- Run depth estimation algorithm on frames in which animals are detected.
+ Estimate animal distance at each second in the video.
 
 ╭─ Options ─────────────────────────────────────────────────────────────────────────────────╮
 │ --filepaths                       PATH          Path to csv containing `filepath` column  │
@@ -78,6 +78,13 @@ $ zamba depth --help
 │                                                 [default: None]                           │
 │ --overwrite               -o                    Overwrite output csv if it exists.        │
 │ --batch-size                      INTEGER       Batch size to use for inference.          │
+│                                                 [default: None]                           │
+│ --num-workers                     INTEGER       Number of subprocesses to use for data    │
+│                                                 loading.                                  │
+│                                                 [default: None]                           │
+│ --gpus                            INTEGER       Number of GPUs to use for inference. If   │
+│                                                 not specifiied, will use all GPUs found   │
+│                                                 on machine.                               │
 │                                                 [default: None]                           │
 │ --model-cache-dir                 PATH          Path to directory for downloading model   │
 │                                                 weights. Alternatively, specify with      │

--- a/docs/docs/models/depth.md
+++ b/docs/docs/models/depth.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-The depth estimation model is one of the winning models from the [Deep Chimpact: Depth Estimation for Wildlife Conservation](https://www.drivendata.org/competitions/82/competition-wildlife-video-depth-estimation/) machine learning challenge hosted by DrivenData. 
+Our depth estimation model is useful for predicting the distance an animal is from the camera, which is an input into models used to estimate animal abundance. The depth model comes from one of the winners of the [Deep Chimpact: Depth Estimation for Wildlife Conservation](https://www.drivendata.org/competitions/82/competition-wildlife-video-depth-estimation/) machine learning challenge hosted by DrivenData.
 
 The goal of this challenge was to use machine learning and advances in monocular (single-lens) depth estimation techniques to automatically estimate the distance between a camera trap and an animal contained in its video footage. The challenge drew on a unique labeled dataset from research teams from the Max Planck Institute for Evolutionary Anthropology (MPI-EVA) and the Wild Chimpanzee Foundation (WCF).
 

--- a/docs/docs/models/species-detection.md
+++ b/docs/docs/models/species-detection.md
@@ -1,6 +1,6 @@
-# Available models
+# Species detection
 
-The algorithms in `zamba` are designed to identify species of animals that appear in camera trap videos. The pretrained models that ship with the `zamba` package are: `blank_nonblank`, `time_distributed`, `slowfast`, and `european`. For more details of each, read on!
+The classification algorithms in `zamba` are designed to identify species of animals that appear in camera trap videos. The pretrained models that ship with the `zamba` package are: `blank_nonblank`, `time_distributed`, `slowfast`, and `european`. For more details of each, read on!
 
 ## Model summary
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Guide to common optional parameters: "extra-options.md"
   - "Available Models":
       - Species detection: "models/species-detection.md"
+      - Depth estimation: "models/depth.md"
       - DensePose: "models/densepose.md"
       - African species performance: "models/td-full-metrics.md"
   - "Advanced Options":
@@ -39,6 +40,9 @@ nav:
           - zamba.data.video: "api-reference/data-video.md"
       - zamba.models:
           - zamba.models.config: "api-reference/models-config.md"
+          - zamba.model.depth_estimation:
+            - zamba.models.depth_estimation.config: "api-reference/depth_config.md"
+            - zamba.models.depth_estimation.depth_manager: "api-reference/depth_manager.md"
           - zamba.models.densepose:
             - zamba.models.densepose.config: "api-reference/densepose_config.md"
             - zamba.models.densepose.densepose_manager: "api-reference/densepose_manager.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ densepose =
     detectron2-densepose @ git+https://github.com/facebookresearch/detectron2@main#subdirectory=projects/DensePose
 
 [flake8]
-ignore = E203, E501, W503, E722
+ignore = E203, E501, W503
 max-line-length = 99
 
 [mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ densepose =
     detectron2-densepose @ git+https://github.com/facebookresearch/detectron2@main#subdirectory=projects/DensePose
 
 [flake8]
-ignore = E203, E501, W503
+ignore = E203, E501, W503, E722
 max-line-length = 99
 
 [mypy]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,7 +190,7 @@ def test_actual_prediction_on_single_video(tmp_path, model):  # noqa: F811
     )
 
 
-def test_depth_cli_options(mocker, tmp_path):
+def test_depth_cli_options(mocker, tmp_path):  # noqa: F811
     mocker.patch("zamba.models.depth_estimation.config.DepthEstimationConfig.run_model", pred_mock)
 
     result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,7 +202,7 @@ def test_depth_cli_options(mocker, tmp_path):  # noqa: F811
     )
 
     assert result.exit_code == 0
-    assert "Run depth estimation algorithm" in result.output
+    assert "Estimate animal distance" in result.output
 
     result = runner.invoke(
         app,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,6 +190,40 @@ def test_actual_prediction_on_single_video(tmp_path, model):  # noqa: F811
     )
 
 
+def test_depth_cli_options(mocker, tmp_path):
+    mocker.patch("zamba.models.depth_estimation.config.DepthEstimationConfig.run_model", pred_mock)
+
+    result = runner.invoke(
+        app,
+        [
+            "depth",
+            "--help",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Run depth estimation algorithm" in result.output
+
+    result = runner.invoke(
+        app,
+        [
+            "depth",
+            "--data-dir",
+            str(TEST_VIDEOS_DIR),
+            "--save-to",
+            str(tmp_path),
+            "--batch-size",
+            12,
+            "--weight-download-region",
+            "asia",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "The following configuration will be used" in result.output
+
+
 @pytest.mark.skipif(
     not bool(int(os.environ.get("ZAMBA_RUN_DENSEPOSE_TESTS", 0))),
     reason="""Skip the densepose specific tests unless environment variable \

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -34,8 +34,9 @@ def test_prediction(two_video_filepaths):
     filepaths = pd.read_csv(two_video_filepaths).filepath.values
     preds = dem.predict(filepaths)
 
-    assert preds.shape == (86, 3)
-    assert preds.distance.notnull().sum() == 41
+    # NB: we expect some small differences in number of detections across ffmpeg versions
+    assert len(preds) > 80
+    assert preds.distance.notnull().sum() > 40
     assert preds.filepath.nunique() == 2
 
     # predictions for reference video
@@ -47,7 +48,7 @@ def test_prediction(two_video_filepaths):
     # confirm distance values
     assert np.isclose(
         ref_vid_preds.loc[[30, 40, 50]].distance.values,
-        [3.1301, 3.1301, 3.6037, 3.6037, 4.0815],
+        [3.1, 3.1, 3.6, 3.6, 4.1],
     ).all()
 
     # check nan rows exist for video with no detection

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from pydantic import ValidationError
 import pytest
 
+from zamba.models.config import GPUS_AVAILABLE
 from zamba.models.depth_estimation import DepthEstimationManager, DepthEstimationConfig
 
 from conftest import ASSETS_DIR, TEST_VIDEOS_DIR
@@ -26,7 +27,9 @@ def two_video_filepaths(tmp_path):
 
 
 def test_prediction(two_video_filepaths):
-    dem = DepthEstimationManager(model_cache_dir=Path(appdirs.user_cache_dir()) / "zamba", gpus=0)
+    dem = DepthEstimationManager(
+        model_cache_dir=Path(appdirs.user_cache_dir()) / "zamba", gpus=GPUS_AVAILABLE
+    )
 
     filepaths = pd.read_csv(two_video_filepaths).filepath.values
     preds = dem.predict(filepaths)

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -1,0 +1,80 @@
+import appdirs
+import pandas as pd
+from pathlib import Path
+from pydantic import ValidationError
+import pytest
+
+from zamba.models.depth_estimation import DepthEstimationManager, DepthEstimationConfig
+
+from conftest import TEST_VIDEOS_DIR
+
+
+@pytest.fixture
+def two_video_filepaths(tmp_path):
+    output_path = tmp_path / "filepaths.csv"
+
+    # from labels csv
+    filepaths = [
+        str(
+            TEST_VIDEOS_DIR
+            / "data/raw/goualougo_2013/gorillas_2013/MPI_FID_20_Duboscia/14-Jun-2013/FID_20_Duboscia_2013-6-14_0083.AVI"
+        ),
+        str(TEST_VIDEOS_DIR / "data/raw/savanna/Grumeti_Tanzania/K38_check3/09190048_Hyena.AVI"),
+    ]
+
+    pd.DataFrame(columns=["filepath"], data=filepaths).to_csv(output_path)
+    return output_path
+
+
+def test_prediction(two_video_filepaths):
+    dem = DepthEstimationManager(model_cache_dir=Path(appdirs.user_cache_dir()) / "zamba")
+
+    filepaths = pd.read_csv(two_video_filepaths).filepath.values
+    preds = dem.predict(filepaths)
+
+    assert preds.shape == (77, 3)
+    assert preds.distance.notnull().sum() == 2
+    assert preds.filepath.nunique() == 2
+
+    # two detections for frame 0
+    assert preds.set_index(["filepath", "time"]).loc[filepaths[0], 0].shape[0] == 2
+
+
+def test_duplicate_filepaths_are_ignored(tmp_path, two_video_filepaths):
+    # create duplicate file that gets skipped
+    df = pd.read_csv(two_video_filepaths)
+    double_df = pd.concat([df, df])
+    assert len(double_df) == len(df) * 2
+
+    config = DepthEstimationConfig(filepaths=double_df, save_to=tmp_path)
+    assert len(config.filepaths) == len(df)
+
+
+def test_save_dir_and_overwrite(tmp_path, two_video_filepaths):
+    # create empty pred file to force use of overwrite
+    preds_path = tmp_path / "depth_estimation.csv"
+    preds_path.touch()
+
+    with pytest.raises(ValidationError):
+        DepthEstimationConfig(filepaths=two_video_filepaths, save_to=preds_path)
+
+    # this works if overwrite is passed
+    config = DepthEstimationConfig(filepaths=two_video_filepaths, save_to=tmp_path, overwrite=True)
+
+    assert config.overwrite
+
+
+def test_invalid_video_is_skipped(tmp_path):
+    # create invalid vid
+    invalid_video = tmp_path / "invalid_vid.mp4"
+    invalid_video.touch()
+
+    config = DepthEstimationConfig(
+        filepaths=pd.DataFrame(columns=["filepath"], data=[invalid_video]),
+        save_to=tmp_path / "preds.csv",
+    )
+    config.run_model()
+
+    # ensure outputs get written out and but is empty since video could not be loaded
+    preds = pd.read_csv(tmp_path / "preds.csv")
+    assert len(preds) == 0

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -34,9 +34,9 @@ def test_prediction(two_video_filepaths):
     filepaths = pd.read_csv(two_video_filepaths).filepath.values
     preds = dem.predict(filepaths)
 
-    # NB: we expect some small differences in number of detections across ffmpeg versions
-    assert len(preds) > 80
-    assert preds.distance.notnull().sum() > 40
+    # NB: we expect some small differences in number of detections across operating systems
+    assert len(preds) >= 80
+    assert preds.distance.notnull().sum() >= 40
     assert preds.filepath.nunique() == 2
 
     # predictions for reference video

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -27,7 +27,7 @@ def two_video_filepaths(tmp_path):
 
 
 def test_prediction(two_video_filepaths):
-    dem = DepthEstimationManager(model_cache_dir=Path(appdirs.user_cache_dir()) / "zamba")
+    dem = DepthEstimationManager(model_cache_dir=Path(appdirs.user_cache_dir()) / "zamba", gpus=0)
 
     filepaths = pd.read_csv(two_video_filepaths).filepath.values
     preds = dem.predict(filepaths)

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -79,3 +79,4 @@ def test_invalid_video_is_skipped(tmp_path):
     # ensure outputs get written out and but is empty since video could not be loaded
     preds = pd.read_csv(tmp_path / "preds.csv")
     assert len(preds) == 0
+    assert (preds.columns == ["filepath", "time", "distance"]).all()

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -59,8 +59,9 @@ def test_save_dir_and_overwrite(tmp_path, two_video_filepaths):
         DepthEstimationConfig(filepaths=two_video_filepaths, save_to=preds_path)
 
     # this works if overwrite is passed
-    config = DepthEstimationConfig(filepaths=two_video_filepaths, save_to=tmp_path, overwrite=True)
-
+    config = DepthEstimationConfig(
+        filepaths=two_video_filepaths, save_to=preds_path, overwrite=True
+    )
     assert config.overwrite
 
 

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -522,14 +522,6 @@ def depth(
         None, "--overwrite", "-o", help="Overwrite output csv if it exists."
     ),
     batch_size: int = typer.Option(None, help="Batch size to use for inference."),
-    model_cache_dir: Path = typer.Option(
-        None,
-        exists=False,
-        help="Path to directory for downloading model weights. Alternatively, specify with environment variable `MODEL_CACHE_DIR`. If not specified, user's cache directory is used.",
-    ),
-    weight_download_region: RegionEnum = typer.Option(
-        None, help="Server region for downloading weights."
-    ),
     num_workers: int = typer.Option(
         None,
         help="Number of subprocesses to use for data loading.",
@@ -537,6 +529,14 @@ def depth(
     gpus: int = typer.Option(
         None,
         help="Number of GPUs to use for inference. If not specifiied, will use all GPUs found on machine.",
+    ),
+    model_cache_dir: Path = typer.Option(
+        None,
+        exists=False,
+        help="Path to directory for downloading model weights. Alternatively, specify with environment variable `MODEL_CACHE_DIR`. If not specified, user's cache directory is used.",
+    ),
+    weight_download_region: RegionEnum = typer.Option(
+        None, help="Server region for downloading weights."
     ),
     yes: bool = typer.Option(
         False,
@@ -557,14 +557,14 @@ def depth(
         predict_dict["overwrite"] = overwrite
     if batch_size is not None:
         predict_dict["batch_size"] = batch_size
-    if model_cache_dir is not None:
-        predict_dict["model_cache_dir"] = model_cache_dir
-    if weight_download_region is not None:
-        predict_dict["weight_download_region"] = weight_download_region
     if num_workers is not None:
         predict_dict["num_workers"] = num_workers
     if gpus is not None:
         predict_dict["gpus"] = num_workers
+    if model_cache_dir is not None:
+        predict_dict["model_cache_dir"] = model_cache_dir
+    if weight_download_region is not None:
+        predict_dict["weight_download_region"] = weight_download_region
 
     try:
         depth_config = DepthEstimationConfig(**predict_dict)
@@ -579,10 +579,10 @@ def depth(
     Save to: {depth_config.save_to}
     Overwrite: {depth_config.overwrite}
     Batch size: {depth_config.batch_size}
-    Model cache: {depth_config.model_cache_dir}
-    Weight download region: {depth_config.weight_download_region}
     Number of workers: {depth_config.num_workers}
     GPUs: {depth_config.gpus}
+    Model cache: {depth_config.model_cache_dir}
+    Weight download region: {depth_config.weight_download_region}
     """
 
     if yes:

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -545,7 +545,7 @@ def depth(
         help="Skip confirmation of configuration and proceed right to prediction.",
     ),
 ):
-    """Run depth estimation algorithm on frames in which animals are detected."""
+    """Estimate animal distance at each second in the video."""
     predict_dict = dict(filepaths=filepaths)
 
     # override if any command line arguments are passed

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -16,6 +16,7 @@ from zamba.models.config import (
 )
 from zamba import MODELS_DIRECTORY
 from zamba.models.densepose import DensePoseConfig, DensePoseOutputEnum
+from zamba.models.depth_estimation import DepthEstimationConfig
 from zamba.models.model_manager import ModelManager
 from zamba.models.utils import RegionEnum
 from zamba.version import __version__
@@ -505,6 +506,73 @@ def densepose(
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             densepose_config.run_model()
+
+
+@app.command()
+def depth(
+    filepaths: Path = typer.Option(
+        None,
+        exists=True,
+        help="Path to csv containing `filepath` column with videos. Paths should be relative to the image directory",
+    ),
+    data_dir: Path = typer.Option(None, exists=True, help="Path to folder containing all images"),
+    save_to: Path = typer.Option(
+        None,
+        help="An optional directory or path for saving the output. Defaults to the current working directory",
+    ),
+    model_cache_dir: Path = typer.Option(
+        None, exists=False, help="Path to directory for model weights."
+    ),
+    batch_size: int = typer.Option(None, help="Batch size to use for inference."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation of configuration and proceed right to prediction.",
+    ),
+):
+    """
+    Run depth estimation algorithm on images. Must provide either a list of full filepaths, or relative
+    filepaths and an image directory.
+    """
+    predict_dict = {"filepaths": filepaths}
+
+    # override if any command line arguments are passed
+    if data_dir is not None:
+        predict_dict["data_dir"] = data_dir
+    if save_to is not None:
+        predict_dict["save_to"] = save_to
+    if model_cache_dir is not None:
+        predict_dict["model_cache_dir"] = model_cache_dir
+    if batch_size is not None:
+        predict_dict["batch_size"] = batch_size
+
+    try:
+        depth_config = DepthEstimationConfig(**predict_dict)
+    except ValidationError as ex:
+        logger.error("Invalid configuration.")
+        raise typer.Exit(ex)
+
+    msg = f"""The following configuration will be used for inference:
+
+    Filepath csv: {filepaths}
+    Data directory: {depth_config.data_dir}
+    Model cache directory: {depth_config.model_cache_dir}
+    Batch size: {depth_config.batch_size}
+    """
+
+    if yes:
+        typer.echo(f"{msg}\n\nSkipping confirmation and proceeding to prediction.")
+    else:
+        yes = typer.confirm(
+            f"{msg}\n\nIs this correct?",
+            abort=False,
+            default=True,
+        )
+
+    if yes:
+        # kick off prediction
+        depth_config.run_model()
 
 
 if __name__ == "__main__":

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -538,11 +538,9 @@ def depth(
     ),
 ):
     """Run depth estimation algorithm on frames in which animals are detected."""
-    predict_dict = dict()
+    predict_dict = dict(filepaths=filepaths)
 
     # override if any command line arguments are passed
-    if filepaths is not None:
-        predict_dict["filepaths"] = filepaths
     if data_dir is not None:
         predict_dict["data_dir"] = data_dir
     if save_to is not None:
@@ -564,7 +562,7 @@ def depth(
 
     msg = f"""The following configuration will be used for inference:
 
-    Filepath csv: {depth_config.filepaths}
+    Filepath csv: {predict_dict["filepaths"]}
     Data directory: {depth_config.data_dir}
     Save to: {depth_config.save_to}
     Overwrite: {depth_config.overwrite}

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -509,7 +509,7 @@ def densepose(
 
 
 @app.command()
-def distance(
+def depth(
     filepaths: Path = typer.Option(
         None, exists=True, help="Path to csv containing `filepath` column with videos."
     ),

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -530,6 +530,10 @@ def depth(
     weight_download_region: RegionEnum = typer.Option(
         None, help="Server region for downloading weights."
     ),
+    num_workers: int = typer.Option(
+        None,
+        help="Number of subprocesses to use for data loading.",
+    ),
     yes: bool = typer.Option(
         False,
         "--yes",
@@ -553,6 +557,8 @@ def depth(
         predict_dict["model_cache_dir"] = model_cache_dir
     if weight_download_region is not None:
         predict_dict["weight_download_region"] = weight_download_region
+    if num_workers is not None:
+        predict_dict["num_workers"] = num_workers
 
     try:
         depth_config = DepthEstimationConfig(**predict_dict)
@@ -569,6 +575,7 @@ def depth(
     Batch size: {depth_config.batch_size}
     Model cache: {depth_config.model_cache_dir}
     Weight download region: {depth_config.weight_download_region}
+    Number of workers: {depth_config.num_workers}
     """
 
     if yes:

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -560,7 +560,7 @@ def depth(
     if num_workers is not None:
         predict_dict["num_workers"] = num_workers
     if gpus is not None:
-        predict_dict["gpus"] = num_workers
+        predict_dict["gpus"] = gpus
     if model_cache_dir is not None:
         predict_dict["model_cache_dir"] = model_cache_dir
     if weight_download_region is not None:

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -537,7 +537,7 @@ def depth(
         help="Skip confirmation of configuration and proceed right to prediction.",
     ),
 ):
-    """Estimate distance of detected animals for every second in the video."""
+    """Run depth estimation algorithm on frames in which animals are detected."""
     predict_dict = dict()
 
     # override if any command line arguments are passed

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -534,6 +534,10 @@ def depth(
         None,
         help="Number of subprocesses to use for data loading.",
     ),
+    gpus: int = typer.Option(
+        None,
+        help="Number of GPUs to use for inference. If not specifiied, will use all GPUs found on machine.",
+    ),
     yes: bool = typer.Option(
         False,
         "--yes",
@@ -559,6 +563,8 @@ def depth(
         predict_dict["weight_download_region"] = weight_download_region
     if num_workers is not None:
         predict_dict["num_workers"] = num_workers
+    if gpus is not None:
+        predict_dict["gpus"] = num_workers
 
     try:
         depth_config = DepthEstimationConfig(**predict_dict)
@@ -576,6 +582,7 @@ def depth(
     Model cache: {depth_config.model_cache_dir}
     Weight download region: {depth_config.weight_download_region}
     Number of workers: {depth_config.num_workers}
+    GPUs: {depth_config.gpus}
     """
 
     if yes:

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -855,7 +855,7 @@ class PredictConfig(ZambaBaseModel):
         duplicated = files_df.filepath.duplicated()
         if duplicated.sum() > 0:
             logger.warning(
-                f"Found {duplicated.sum()} duplicate row(s) in filepaths csv. Dropping duplicates so predictions will have one row per video."
+                f"Found {duplicated.sum():,} duplicate row(s) in filepaths csv. Dropping duplicates so predictions will have one row per video."
             )
             files_df = files_df[["filepath"]].drop_duplicates()
 

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -852,10 +852,10 @@ class PredictConfig(ZambaBaseModel):
             files_df = files_df[["filepath"]]
 
         # can only contain one row per filepath
-        num_duplicates = len(files_df) - files_df.filepath.nunique()
-        if num_duplicates > 0:
+        duplicated = files_df.filepath.duplicated()
+        if duplicated.sum() > 0:
             logger.warning(
-                f"Found {num_duplicates} duplicate row(s) in filepaths csv. Dropping duplicates so predictions will have one row per video."
+                f"Found {duplicated.sum()} duplicate row(s) in filepaths csv. Dropping duplicates so predictions will have one row per video."
             )
             files_df = files_df[["filepath"]].drop_duplicates()
 

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -214,6 +214,38 @@ def validate_model_name_and_checkpoint(cls, values):
     return values
 
 
+def get_filepaths(cls, values):
+    """If no file list is passed, get all files in data directory. Warn if there
+    are unsupported suffixes. Filepaths is set to a dataframe, where column `filepath`
+    contains files with valid suffixes.
+    """
+    if values["filepaths"] is None:
+        logger.info(f"Getting files in {values['data_dir']}.")
+        files = []
+        new_suffixes = []
+
+        # iterate over all files in data directory
+        for f in values["data_dir"].rglob("*"):
+            if f.is_file():
+                # keep just files with supported suffixes
+                if f.suffix.lower() in VIDEO_SUFFIXES:
+                    files.append(f.resolve())
+                else:
+                    new_suffixes.append(f.suffix.lower())
+
+        if len(new_suffixes) > 0:
+            logger.warning(
+                f"Ignoring {len(new_suffixes)} file(s) with suffixes {set(new_suffixes)}. To include, specify all video suffixes with a VIDEO_SUFFIXES environment variable."
+            )
+
+        if len(files) == 0:
+            raise ValueError(f"No video files found in {values['data_dir']}.")
+
+        logger.info(f"Found {len(files)} videos in {values['data_dir']}.")
+        values["filepaths"] = pd.DataFrame(files, columns=["filepath"])
+    return values
+
+
 class ZambaBaseModel(BaseModel):
     """Set defaults for all models that inherit from the pydantic base model."""
 
@@ -360,8 +392,8 @@ class TrainConfig(ZambaBaseModel):
             when the metric stops improving. Defaults to EarlyStoppingConfig(monitor='val_macro_f1',
             patience=5, verbose=True, mode='max').
         weight_download_region (str): s3 region to download pretrained weights from.
-            Options are "us" (United States), "eu" (European Union), or "asia"
-            (Asia Pacific). Defaults to "us".
+            Options are "us" (United States), "eu" (Europe), or "asia" (Asia Pacific).
+            Defaults to "us".
         split_proportions (dict): Proportions used to divide data into training,
             validation, and holdout sets if a if a "split" column is not included in
             labels. Defaults to "train": 3, "val": 1, "holdout": 1.
@@ -704,8 +736,8 @@ class PredictConfig(ZambaBaseModel):
             score as a single prediction for each video. If False, return probabilty
             scores for each species. Defaults to False.
         weight_download_region (str): s3 region to download pretrained weights from.
-            Options are "us" (United States), "eu" (European Union), or "asia"
-            (Asia Pacific). Defaults to "us".
+            Options are "us" (United States), "eu" (Europe), or "asia" (Asia Pacific).
+            Defaults to "us".
         skip_load_validation (bool): By default, zamba runs a check to verify that
             all videos can be loaded and skips files that cannot be loaded. This can
             be time intensive, depending on how many videos there are. If you are very
@@ -801,37 +833,9 @@ class PredictConfig(ZambaBaseModel):
                 )
         return values
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def get_filepaths(cls, values):
-        """If no file list is passed, get all files in data directory. Warn if there
-        are unsupported suffixes. Filepaths is set to a dataframe, where column `filepath`
-        contains files with valid suffixes.
-        """
-        if values["filepaths"] is None:
-            logger.info(f"Getting files in {values['data_dir']}.")
-            files = []
-            new_suffixes = []
-
-            # iterate over all files in data directory
-            for f in values["data_dir"].rglob("*"):
-                if f.is_file():
-                    # keep just files with supported suffixes
-                    if f.suffix.lower() in VIDEO_SUFFIXES:
-                        files.append(f.resolve())
-                    else:
-                        new_suffixes.append(f.suffix.lower())
-
-            if len(new_suffixes) > 0:
-                logger.warning(
-                    f"Ignoring {len(new_suffixes)} file(s) with suffixes {set(new_suffixes)}. To include, specify all video suffixes with a VIDEO_SUFFIXES environment variable."
-                )
-
-            if len(files) == 0:
-                raise ValueError(f"No video files found in {values['data_dir']}.")
-
-            logger.info(f"Found {len(files)} videos in {values['data_dir']}.")
-            values["filepaths"] = pd.DataFrame(files, columns=["filepath"])
-        return values
+    _get_filepaths = root_validator(allow_reuse=True, pre=False, skip_on_failure=True)(
+        get_filepaths
+    )
 
     @root_validator(skip_on_failure=True)
     def validate_files(cls, values):

--- a/zamba/models/densepose/config.py
+++ b/zamba/models/densepose/config.py
@@ -125,7 +125,7 @@ class DensePoseConfig(ZambaBaseModel):
         duplicated = files_df.filepath.duplicated()
         if duplicated.sum() > 0:
             logger.warning(
-                f"Found {duplicated.sum()} duplicate row(s) in filepaths csv. Dropping duplicates so predictions will have one row per video."
+                f"Found {duplicated.sum():,} duplicate row(s) in filepaths csv. Dropping duplicates so predictions will have one row per video."
             )
             files_df = files_df[["filepath"]].drop_duplicates()
 

--- a/zamba/models/densepose/config.py
+++ b/zamba/models/densepose/config.py
@@ -122,10 +122,10 @@ class DensePoseConfig(ZambaBaseModel):
             raise ValueError(f"{values['filepaths']} must contain a `filepath` column.")
 
         # can only contain one row per filepath
-        num_duplicates = len(files_df) - files_df.filepath.nunique()
-        if num_duplicates > 0:
+        duplicated = files_df.filepath.duplicated()
+        if duplicated.sum() > 0:
             logger.warning(
-                f"Found {num_duplicates} duplicate row(s) in filepaths csv. Dropping duplicates so predictions will have one row per video."
+                f"Found {duplicated.sum()} duplicate row(s) in filepaths csv. Dropping duplicates so predictions will have one row per video."
             )
             files_df = files_df[["filepath"]].drop_duplicates()
 

--- a/zamba/models/densepose/config.py
+++ b/zamba/models/densepose/config.py
@@ -17,7 +17,6 @@ from zamba.models.config import (
 )
 from zamba.models.densepose.densepose_manager import MODELS, DensePoseManager
 from zamba.models.utils import RegionEnum
-from zamba.settings import VIDEO_SUFFIXES
 
 
 class DensePoseOutputEnum(Enum):

--- a/zamba/models/depth_estimation/__init__.py
+++ b/zamba/models/depth_estimation/__init__.py
@@ -1,2 +1,2 @@
-from .depth_manager import DepthEstimationManager, MODELS  # noqa
+from .depth_manager import DepthDataset, DepthEstimationManager, MODELS  # noqa
 from .config import DepthEstimationConfig  # noqa

--- a/zamba/models/depth_estimation/__init__.py
+++ b/zamba/models/depth_estimation/__init__.py
@@ -1,0 +1,2 @@
+from .depth_manager import DepthEstimationManager, MODELS  # noqa
+from .config import DepthEstimationConfig  # noqa

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -109,10 +109,10 @@ class DepthEstimationConfig(ZambaBaseModel):
             raise ValueError(f"{values['filepaths']} must contain a `filepath` column.")
 
         # can only contain one row per filepath
-        num_duplicates = len(files_df) - files_df.filepath.nunique()
-        if num_duplicates > 0:
+        duplicated = files_df.filepath.duplicated()
+        if duplicated.sum() > 0:
             logger.warning(
-                f"Found {num_duplicates} duplicate row(s) in filepaths csv. Dropping duplicates."
+                f"Found {duplicated.sum()} duplicate row(s) in filepaths csv. Dropping duplicates."
             )
             files_df = files_df[["filepath"]].drop_duplicates()
 

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -1,8 +1,8 @@
 import os
+from pathlib import Path
 
 from loguru import logger
 import pandas as pd
-from pathlib import Path
 from pydantic import DirectoryPath, FilePath, validator, root_validator
 from typing import Optional, Union
 
@@ -17,8 +17,7 @@ from zamba.models.utils import RegionEnum
 
 
 class DepthEstimationConfig(ZambaBaseModel):
-    """Configuration for running depth estimation on images. At a minimum, must provide either
-    a list of full filepaths, or a list of relative filepaths along with the data_dir
+    """Configuration for running depth estimation on videos.
 
     Args:
         filepaths (FilePath, optional): Path to a CSV containing videos for inference, with one row per
@@ -58,10 +57,8 @@ class DepthEstimationConfig(ZambaBaseModel):
         )
 
         predictions = dm.predict(self.filepaths)
-
-        if not self.save_to.exists():
-            predictions.to_csv(self.save_to, index=False)
-            logger.info(f"Depth predictions saved to {self.save_to}")
+        predictions.to_csv(self.save_to, index=False)
+        logger.info(f"Depth predictions saved to {self.save_to}")
 
     _get_filepaths = root_validator(allow_reuse=True, pre=False, skip_on_failure=True)(
         get_filepaths

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -1,0 +1,107 @@
+import os
+
+from loguru import logger
+import pandas as pd
+from pathlib import Path
+from pydantic.class_validators import root_validator, validator
+from typing import Optional, Union, List
+
+from zamba.models.config import (
+    ZambaBaseModel,
+    check_files_exist_and_load,
+    get_filepaths,
+    validate_model_cache_dir,
+)
+from zamba.models.depth_estimation.depth_manager import DepthEstimationManager
+from zamba.models.utils import RegionEnum
+from zamba.settings import VIDEO_SUFFIXES
+
+
+class DepthEstimationConfig(ZambaBaseModel):
+    """Configuration for running depth estimation on images. At a minimum, must provide either
+    a list of full filepaths, or a list of relative filepaths along with the data_dir
+
+    Args:
+        filepaths (FilePath): Path to a CSV containing videos for inference, with one row per
+            video in the data_dir. There must be a column called 'filepath' (absolute or
+            relative to the data_dir). If None, uses all files in data_dir. Defaults to None.
+        data_dir (DirectoryPath): Path to a directory containing videos for inference.
+            Defaults to the working directory.
+        save_to (Path, optional): Either a path or a directory to save the predicted depths. If a
+            directory is provided, predictions will be saved to depth_predictions.csv in that
+            directory. Defaults to os.getcwd()
+        model_cache_dir (Path, optional): Path for downloading and saving model weights.
+            Defaults to env var `MODEL_CACHE_DIR` or the OS app cache dir.
+        weight_download_region (str): s3 region to download pretrained weights from. Options are
+            "us" (United States), "eu" (Europe), or "asia" (Asia Pacific). Defaults to "us".
+        batch_size (int): Batch size to use for inference. Defaults to 64. Note: a batch is a set
+            of frames, not videos, for the depth model.
+    """
+
+    filepaths: Union[Path, List[Union[Path, str]]]
+    data_dir: Optional[Path]
+    save_to: Optional[Path] = None
+    model_cache_dir: Optional[Path] = None
+    weight_download_region: RegionEnum = RegionEnum("us")
+    batch_size: int = 64
+
+    _validate_cache_dir = validator("model_cache_dir", allow_reuse=True, always=True)(
+        validate_model_cache_dir
+    )
+
+    def run_model(self):
+        # get path to save predictions
+        if self.save_to is None:
+            save_path = Path(os.getcwd()) / "depth_predictions.csv"
+        elif self.save_to.suffix:
+            save_path = self.save_to
+        else:
+            save_path = self.save_to / "depth_predictions.csv"
+
+        # TODO; should this error and not warn
+        if save_path.exists():
+            logger.warning(f"Predictions will NOT be saved out because {save_path} already exists")
+
+        dm = DepthEstimationManager(
+            model_cache_dir=self.model_cache_dir,
+            batch_size=self.batch_size,
+            weight_download_region=self.weight_download_region,
+        )
+
+        predictions = dm.predict(self.filepaths)
+
+        if not save_path.exists():
+            predictions.to_csv(save_path, index=False)
+            logger.info(f"Depth predictions saved to {save_path}")
+
+    _get_filepaths = root_validator(allow_reuse=True, pre=False, skip_on_failure=True)(
+        get_filepaths
+    )
+
+    @root_validator(skip_on_failure=True)
+    def validate_files(cls, values):
+        # if globbing from data directory, already have valid dataframe
+        if isinstance(values["filepaths"], pd.DataFrame):
+            files_df = values["filepaths"]
+        else:
+            # make into dataframe even if only one column for clearer indexing
+            files_df = pd.DataFrame(pd.read_csv(values["filepaths"]))
+
+        if "filepath" not in files_df.columns:
+            raise ValueError(f"{values['filepaths']} must contain a `filepath` column.")
+
+        # can only contain one row per filepath
+        num_duplicates = len(files_df) - files_df.filepath.nunique()
+        if num_duplicates > 0:
+            logger.warning(
+                f"Found {num_duplicates} duplicate row(s) in filepaths csv. Dropping duplicates."
+            )
+            files_df = files_df[["filepath"]].drop_duplicates()
+
+        values["filepaths"] = check_files_exist_and_load(
+            df=files_df,
+            data_dir=values["data_dir"],
+            skip_load_validation=True,  # just check files exist
+        ).filepath.values.tolist()
+
+        return values

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -35,6 +35,8 @@ class DepthEstimationConfig(ZambaBaseModel):
             Defaults to env var `MODEL_CACHE_DIR` or the OS app cache dir.
         weight_download_region (str): s3 region to download pretrained weights from. Options are
             "us" (United States), "eu" (Europe), or "asia" (Asia Pacific). Defaults to "us".
+        num_workers (int): Number of subprocesses to use for data loading. The maximum value is
+           the number of CPUs in the system. Defaults to 8.
     """
 
     filepaths: Optional[Union[FilePath, pd.DataFrame]] = None
@@ -44,6 +46,7 @@ class DepthEstimationConfig(ZambaBaseModel):
     batch_size: int = 64
     model_cache_dir: Optional[Path] = None
     weight_download_region: RegionEnum = RegionEnum("us")
+    num_workers: int = 8
 
     class Config:
         # support pandas dataframe
@@ -54,6 +57,7 @@ class DepthEstimationConfig(ZambaBaseModel):
             model_cache_dir=self.model_cache_dir,
             batch_size=self.batch_size,
             weight_download_region=self.weight_download_region,
+            num_workers=self.num_workers,
         )
 
         predictions = dm.predict(self.filepaths)

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -4,7 +4,7 @@ from loguru import logger
 import pandas as pd
 from pathlib import Path
 from pydantic import DirectoryPath, FilePath, validator, root_validator
-from typing import Optional
+from typing import Optional, Union
 
 from zamba.models.config import (
     ZambaBaseModel,
@@ -14,7 +14,6 @@ from zamba.models.config import (
 )
 from zamba.models.depth_estimation.depth_manager import DepthEstimationManager
 from zamba.models.utils import RegionEnum
-from zamba.settings import VIDEO_SUFFIXES
 
 
 class DepthEstimationConfig(ZambaBaseModel):
@@ -39,13 +38,17 @@ class DepthEstimationConfig(ZambaBaseModel):
             "us" (United States), "eu" (Europe), or "asia" (Asia Pacific). Defaults to "us".
     """
 
-    filepaths: Optional[FilePath] = None
+    filepaths: Optional[Union[FilePath, pd.DataFrame]] = None
     data_dir: DirectoryPath = ""
     save_to: Optional[Path] = None
     overwrite: bool = False
     batch_size: int = 64
     model_cache_dir: Optional[Path] = None
     weight_download_region: RegionEnum = RegionEnum("us")
+
+    class Config:
+        # support pandas dataframe
+        arbitrary_types_allowed = True
 
     def run_model(self):
         dm = DepthEstimationManager(

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -57,6 +57,7 @@ class DepthEstimationConfig(ZambaBaseModel):
         )
 
         predictions = dm.predict(self.filepaths)
+        self.save_to.parent.mkdir(parents=True, exist_ok=True)
         predictions.to_csv(self.save_to, index=False)
         logger.info(f"Depth predictions saved to {self.save_to}")
 

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -10,6 +10,7 @@ from zamba.models.config import (
     ZambaBaseModel,
     check_files_exist_and_load,
     get_filepaths,
+    GPUS_AVAILABLE,
     validate_model_cache_dir,
 )
 from zamba.models.depth_estimation.depth_manager import DepthEstimationManager
@@ -37,6 +38,8 @@ class DepthEstimationConfig(ZambaBaseModel):
             "us" (United States), "eu" (Europe), or "asia" (Asia Pacific). Defaults to "us".
         num_workers (int): Number of subprocesses to use for data loading. The maximum value is
            the number of CPUs in the system. Defaults to 8.
+        gpus (int): Number of GPUs to use for inference. Defaults to all of the available GPUs
+            found on the machine.
     """
 
     filepaths: Optional[Union[FilePath, pd.DataFrame]] = None
@@ -47,6 +50,7 @@ class DepthEstimationConfig(ZambaBaseModel):
     model_cache_dir: Optional[Path] = None
     weight_download_region: RegionEnum = RegionEnum("us")
     num_workers: int = 8
+    gpus: int = GPUS_AVAILABLE
 
     class Config:
         # support pandas dataframe
@@ -58,6 +62,7 @@ class DepthEstimationConfig(ZambaBaseModel):
             batch_size=self.batch_size,
             weight_download_region=self.weight_download_region,
             num_workers=self.num_workers,
+            gpus=self.gpus,
         )
 
         predictions = dm.predict(self.filepaths)

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -11,6 +11,7 @@ from zamba.models.config import (
     check_files_exist_and_load,
     get_filepaths,
     GPUS_AVAILABLE,
+    validate_gpus,
     validate_model_cache_dir,
 )
 from zamba.models.depth_estimation.depth_manager import DepthEstimationManager
@@ -77,6 +78,8 @@ class DepthEstimationConfig(ZambaBaseModel):
     _validate_cache_dir = validator("model_cache_dir", allow_reuse=True, always=True)(
         validate_model_cache_dir
     )
+
+    _validate_gpus = validator("gpus", allow_reuse=True, pre=True)(validate_gpus)
 
     @root_validator(skip_on_failure=True)
     def validate_save_to(cls, values):

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -115,7 +115,7 @@ class DepthEstimationConfig(ZambaBaseModel):
         duplicated = files_df.filepath.duplicated()
         if duplicated.sum() > 0:
             logger.warning(
-                f"Found {duplicated.sum()} duplicate row(s) in filepaths csv. Dropping duplicates."
+                f"Found {duplicated.sum():,} duplicate row(s) in filepaths csv. Dropping duplicates."
             )
             files_df = files_df[["filepath"]].drop_duplicates()
 

--- a/zamba/models/depth_estimation/config.py
+++ b/zamba/models/depth_estimation/config.py
@@ -71,8 +71,9 @@ class DepthEstimationConfig(ZambaBaseModel):
         validate_model_cache_dir
     )
 
-    @validator("save_to", always=True)
-    def validate_save_dir(cls, save_to):
+    @root_validator(skip_on_failure=True)
+    def validate_save_to(cls, values):
+        save_to = values["save_to"]
         if save_to is None:
             save_path = Path(os.getcwd()) / "depth_predictions.csv"
         elif save_to.suffix:
@@ -80,12 +81,13 @@ class DepthEstimationConfig(ZambaBaseModel):
         else:
             save_path = save_to / "depth_predictions.csv"
 
-        if save_path.exists():
+        if save_path.exists() and not values["overwrite"]:
             raise ValueError(
                 f"{save_path} already exists. If you would like to overwrite, set overwrite=True."
             )
 
-        return save_path
+        values["save_to"] = save_path
+        return values
 
     @root_validator(skip_on_failure=True)
     def validate_files(cls, values):

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -45,6 +45,8 @@ class DepthDataset(torch.utils.data.Dataset):
         self.width = 480
         self.channels = 3
         self.window_size = 2
+        # first frames are swapped; this maintains the bug in the original code
+        self.order = [-1, -2, 0, 1, 2]
         self.num_frames = self.window_size * 2 + 1
         self.fps = 1
 
@@ -140,6 +142,10 @@ class DepthDataset(torch.utils.data.Dataset):
                     det_frame - self.window_size, det_frame + self.window_size + 1
                 )
             ]
+        )
+
+        input = np.concatenate(
+            [self.cached_frames[det_video][f"frame_{frame_idx}"] for frame_idx in self.order],
         )
 
         tensor = torch.from_numpy(input)

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -79,7 +79,7 @@ class DepthDataset(torch.utils.data.Dataset):
                                     Image.fromarray(arr[i]).resize((self.width, self.height))
                                 )
                             except:
-                                selected_frame = np.zeros((self.height, self.width))
+                                selected_frame = np.zeros((self.height, self.width, self.channels))
 
                             cached_frames[video_filepath][f"frame_{i}"] = selected_frame
 

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -52,7 +52,7 @@ class DepthDataset(torch.utils.data.Dataset):
                 logger.warning(f"Video {video_filepath} could not be loaded. Skipping.")
                 continue
 
-            # add video to cached dict with length (number of seconds since fps=1)
+            # add video entry to cached dict with length (number of seconds since fps=1)
             cached_frames[video_filepath] = dict(video_length=len(arr))
 
             # get detections in each frame
@@ -125,9 +125,6 @@ class DepthDataset(torch.utils.data.Dataset):
                 f"frame_{frame_idx}"
             ]
             n += self.channels
-
-        # TODO: original order was -1, -2, 0, 1, 2; TBD if we want to maintain that bug
-        # TODO: mask out other detection from the same frame?
 
         # normalize and convert to tensor
         input = normalize(input)

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -131,7 +131,7 @@ class DepthDataset(torch.utils.data.Dataset):
         input = normalize(input)
         tensor = torch.from_numpy(input)
 
-        # keep track of video name and time
+        # keep track of video name and time as well
         return tensor, det_video, det_frame
 
 
@@ -143,7 +143,6 @@ class DepthEstimationManager:
         weight_download_region: RegionEnum = RegionEnum("us"),
         batch_size: int = 64,
         tta: int = 2,
-        use_log: bool = False,
         num_workers: int = 8,
     ):
         """Create a depth estimation manager object

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -233,7 +233,7 @@ class DepthEstimationManager:
                         predictions.append((vid, t, d))
 
         predictions = pd.DataFrame(predictions, columns=["filepath", "time", "distance"],).round(
-            {"distance": 4}
+            {"distance": 1}
         )  # round to useful number of decimal places
 
         logger.info("Processing output.")

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -143,6 +143,7 @@ class DepthEstimationManager:
         batch_size: int = 64,
         tta: int = 2,
         use_log: bool = False,
+        num_workers: int = 8,
     ):
         """Create a depth estimation manager object
 
@@ -156,10 +157,13 @@ class DepthEstimationManager:
             tta (int, optional): Number of flips to apply for test time augmentation.
             use_log (bool, optional): Whether to take the exponential of the predictions
                 (see torch.special.expm1). Defaults to False.
+            num_workers (int): Number of subprocesses to use for data loading. The maximum value is
+                the number of CPUs in the system. Defaults to 8.
         """
         self.batch_size = batch_size
         self.tta = tta
         self.use_log = use_log
+        self.num_workers = num_workers
 
         model = MODELS["depth"]
 
@@ -190,7 +194,7 @@ class DepthEstimationManager:
             shuffle=False,
             sampler=None,
             collate_fn=None,
-            num_workers=min(self.batch_size, 8),
+            num_workers=self.num_workers,
             pin_memory=False,
             persistent_workers=True,
         )

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -11,8 +11,8 @@ from tqdm import tqdm
 
 from zamba.data.video import load_video_frames
 from zamba.models.utils import RegionEnum, download_weights
-from zamba.pytorch.transforms import ConvertHWCtoCHW, Uint8ToFloat
 from zamba.object_detection.yolox.megadetector_lite_yolox import MegadetectorLiteYoloX
+from zamba.pytorch.transforms import ConvertHWCtoCHW, Uint8ToFloat
 
 
 MODELS = dict(

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -145,7 +145,7 @@ class DepthDataset(torch.utils.data.Dataset):
         )
 
         input = np.concatenate(
-            [self.cached_frames[det_video][f"frame_{frame_idx}"] for frame_idx in self.order],
+            [self.cached_frames[det_video][f"frame_{det_frame + i}"] for i in self.order],
         )
 
         tensor = torch.from_numpy(input)

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -157,14 +157,11 @@ class DepthEstimationManager:
             batch_size (int, optional): Batch size to use for inference. Defaults to 64.
                 Note: a batch is a set of frames, not videos, for the depth model.
             tta (int, optional): Number of flips to apply for test time augmentation.
-            use_log (bool, optional): Whether to take the exponential of the predictions
-                (see torch.special.expm1). Defaults to False.
             num_workers (int): Number of subprocesses to use for data loading. The maximum value is
                 the number of CPUs in the system. Defaults to 8.
         """
         self.batch_size = batch_size
         self.tta = tta
-        self.use_log = use_log
         self.num_workers = num_workers
         self.gpus = gpus
 
@@ -221,9 +218,6 @@ class DepthEstimationManager:
                         distance[:bs] += logits
 
                     distance /= self.tta
-
-                    if self.use_log:
-                        distance.expm1_()
 
                     time = time.numpy()
 

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -24,12 +24,6 @@ MODELS = dict(
 )
 
 
-# def normalize(img):
-#     img = np.transpose(img, (2, 0, 1))
-#     img = img.astype("float32") / 255
-#     return img
-
-
 def depth_transforms(size):
     return transforms.Compose(
         [
@@ -100,7 +94,8 @@ class DepthDataset(torch.utils.data.Dataset):
                                     (self.height, self.width, self.channels), dtype=int
                                 )
 
-                            selected_frame = transform(torch.tensor(selected_frame))
+                            # put channels first, resize, divide by 255
+                            selected_frame = transform(torch.tensor(selected_frame)).numpy()
 
                             cached_frames[video_filepath][f"frame_{i}"] = selected_frame
 

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -139,6 +139,7 @@ class DepthEstimationManager:
     def __init__(
         self,
         model_cache_dir: Path,
+        gpus: int,
         weight_download_region: RegionEnum = RegionEnum("us"),
         batch_size: int = 64,
         tta: int = 2,
@@ -149,6 +150,7 @@ class DepthEstimationManager:
 
         Args:
             model_cache_dir (Path): Path for downloading and saving model weights.
+            gpus (int): Number of GPUs to use for inference.
             weight_download_region (str): s3 region to download pretrained weights from.
                 Options are "us" (United States), "eu" (Europe), or "asia" (Asia Pacific).
                 Defaults to "us".
@@ -164,6 +166,7 @@ class DepthEstimationManager:
         self.tta = tta
         self.use_log = use_log
         self.num_workers = num_workers
+        self.gpus = gpus
 
         model = MODELS["depth"]
 
@@ -174,11 +177,10 @@ class DepthEstimationManager:
                 model["weights"], model_cache_dir, weight_download_region
             )
 
-        # automatically use CPU if no cuda available
-        if not torch.cuda.is_available():
-            self.device = "cpu"
-        else:
+        if self.gpus > 0:
             self.device = "cuda"
+        else:
+            self.device = "cpu"
 
     def predict(self, filepaths):
         """Generate predictions for a list of video filepaths."""

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -175,8 +175,7 @@ class DepthEstimationManager:
             self.device = "cuda"
 
     def predict(self, filepaths):
-        """Generate predictions for a list of filepaths, each representing one target frame.
-        Filepaths should be given relative to the data_dir."""
+        """Generate predictions for a list of video filepaths."""
 
         # load model
         model = torch.jit.load(self.model_weights, map_location=self.device).eval()

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -98,7 +98,7 @@ class DepthDataset(torch.utils.data.Dataset):
             del arr
 
         self.detection_dict = detection_dict
-        self.detection_indices = detection_dict.keys()
+        self.detection_indices = list(detection_dict.keys())
         self.cached_frames = cached_frames
 
     def __len__(self):

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -1,0 +1,247 @@
+from PIL import Image
+from loguru import logger
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import torch
+import torch.utils
+import torch.utils.data
+from tqdm import tqdm
+from typing import Optional
+
+from zamba.data.video import load_video_frames
+from zamba.models.utils import RegionEnum, download_weights
+from zamba.object_detection.yolox.megadetector_lite_yolox import MegadetectorLiteYoloX
+
+
+MODELS = dict(
+    depth=dict(
+        private_weights_url="s3://drivendata-client-zamba/depth_estimation_winner_weights/second_place/tf_efficientnetv2_l_in21k_2_5_pl4/model_best.pt",
+        weights="zamba_depth_30aaa90525.pt",
+    )
+)
+
+
+def normalize(img):
+    img = np.transpose(img, (2, 0, 1))
+    img = img.astype("float32") / 255
+    return img
+
+
+class DepthDataset(torch.utils.data.Dataset):
+    def __init__(self, filepaths):
+
+        self.height = 270
+        self.width = 480
+        self.channels = 3
+        self.window_size = 2
+        self.num_frames = self.window_size * 2 + 1
+
+        mdlite = MegadetectorLiteYoloX()
+        cached_frames = dict()
+        detection_dict = dict()
+
+        logger.info(f"Running object detection on {len(filepaths)} videos.")
+        for video_filepath in tqdm(filepaths):
+
+            # get video array at 1 fps, use full size for detecting objects
+            logger.debug(f"Loading video: {video_filepath}")
+            try:
+                arr = load_video_frames(video_filepath, fps=1)
+            except:
+                logger.warning(f"Video {video_filepath} could not be loaded. Skipping.")
+                continue
+
+            # add video to cached dict with length (number of seconds since fps=1)
+            cached_frames[video_filepath] = dict(video_length=len(arr))
+
+            # get detections in each frame
+            logger.debug(f"Detecting video: {video_filepath}")
+            detections_per_frame = mdlite.detect_video(video_arr=arr)
+
+            # iterate over frames
+            for frame_idx, (detections, scores) in enumerate(detections_per_frame):
+
+                # if anything is detected in the frame, save out relevant frames
+                if len(detections) > 0:
+                    logger.debug(f"{len(detections)} detection(s) found at second {frame_idx}.")
+
+                    # get frame indices around frame with detection
+                    min_frame = frame_idx - self.window_size
+                    max_frame = frame_idx + self.window_size
+
+                    # add relevant resized frames to dict if not already added
+                    # if index is before start or after end of video, use an array of zeros
+                    for i in range(min_frame, max_frame + 1):
+                        if f"frame_{i}" not in cached_frames[video_filepath].keys():
+                            try:
+                                selected_frame = np.array(
+                                    # PIL expects size to be (w, h)
+                                    Image.fromarray(arr[i]).resize((self.width, self.height))
+                                )
+                            except:
+                                selected_frame = np.zeros((self.height, self.width))
+
+                            cached_frames[video_filepath][f"frame_{i}"] = selected_frame
+
+                    # iterate over detections in frame to create universal detection ID
+                    for i, (detection, score) in enumerate(zip(detections, scores)):
+                        universal_det_id = f"{i}_{frame_idx}_{video_filepath}"
+
+                        # save out bounding box and score info in case we want to mask out portions
+                        detection_dict[universal_det_id] = dict(
+                            bbox=detection,
+                            score=score,
+                            frame=frame_idx,
+                            video=video_filepath,
+                        )
+
+            del arr
+
+        self.detection_dict = detection_dict
+        self.detection_indices = detection_dict.keys()
+        self.cached_frames = cached_frames
+
+    def __len__(self):
+        return len(self.detection_indices)
+
+    def __getitem__(self, index):
+        """Given the index of the target image, returns a tuple of the stacked image array, the image
+        filename stem, and the time into the video for the target image.
+        """
+
+        # get detection info
+        detection_idx = self.detection_indices[index]
+        det_metadata = self.detection_dict[detection_idx]
+        det_frame = det_metadata["frame"]
+        det_video = det_metadata["video"]
+
+        # set up input array of frames within window of detection
+        # frames are stacked channel-wise
+        input = np.zeros((self.height, self.width, self.channels * self.num_frames))
+        n = 0
+        for frame_idx in range(det_frame - self.window_size, det_frame + self.window_size + 1):
+            input[:, :, n : n + self.channels] = self.cached_frames[det_video][
+                f"frame_{frame_idx}"
+            ]
+            n += self.channels
+
+        # TODO: original order was -1, -2, 0, 1, 2; TBD if we want to maintain that bug
+        # TODO: mask out other detection from the same frame?
+
+        # normalize and convert to tensor
+        input = normalize(input)
+        tensor = torch.from_numpy(input)
+
+        # keep track of video name and time
+        return tensor, det_video, det_frame
+
+
+class DepthEstimationManager:
+    def __init__(
+        self,
+        model_cache_dir: Optional[Path] = None,
+        weight_download_region: RegionEnum = RegionEnum("us"),
+        batch_size: int = 64,
+        tta: int = 2,
+        use_log: bool = False,
+    ):
+        """Create a depth estimation manager object
+
+        Args:
+            model_cache_dir (Path, optional): Path for downloading and saving model weights.
+                Defaults to env var `MODEL_CACHE_DIR` or the OS app cache dir.
+            weight_download_region (str): s3 region to download pretrained weights from.
+                Options are "us" (United States), "eu" (Europe), or "asia" (Asia Pacific).
+                Defaults to "us".
+            batch_size (int, optional): Batch size to use for inference. Defaults to 64.
+                Note: a batch is a set of frames, not videos, for the depth model.
+            tta (int, optional): Number of flips to apply for test time augmentation.
+            use_log (bool, optional): Whether to take the exponential of the predictions
+                (see torch.special.expm1). Defaults to False.
+        """
+        self.batch_size = batch_size
+        self.tta = tta
+        self.use_log = use_log
+
+        model = MODELS["depth"]
+
+        self.model_weights = model_cache_dir / model["weights"]
+        if not self.model_weights.exists():
+            model_cache_dir.mkdir(parents=True, exist_ok=True)
+            self.model_weights = download_weights(
+                model["weights"], model_cache_dir, weight_download_region
+            )
+
+        # automatically use CPU if no cuda available
+        if not torch.cuda.is_available():
+            self.device = "cpu"
+        else:
+            self.device = "cuda"
+
+    def predict(self, filepaths):
+        """Generate predictions for a list of filepaths, each representing one target frame.
+        Filepaths should be given relative to the data_dir."""
+
+        # load model
+        model = torch.jit.load(self.model_weights, map_location=self.device).eval()
+
+        # load dataset
+        test_dataset = DepthDataset(filepaths)
+        test_loader = torch.utils.data.DataLoader(
+            test_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            sampler=None,
+            collate_fn=None,
+            num_workers=min(self.batch_size, 8),
+            pin_memory=False,
+            persistent_workers=True,
+        )
+
+        logger.info("Generating depth predictions for detected animals.")
+        predictions = []
+        with torch.no_grad():
+            with tqdm(test_loader) as pbar:
+                distance: torch.Tensor = torch.zeros(self.batch_size, device=self.device)
+                for image, filepath, time in pbar:
+                    bs = image.size(0)
+                    image = image.to(self.device, non_blocking=True)
+
+                    distance.zero_()
+                    logits = model(image)
+                    logits = logits.squeeze(1)
+                    distance[:bs] += logits
+
+                    if self.tta > 1:
+                        logits = model(torch.flip(image, dims=[-1]))
+                        logits = logits.squeeze(1)
+                        distance[:bs] += logits
+
+                    distance /= self.tta
+
+                    if self.use_log:
+                        distance.expm1_()
+
+                    time = time.numpy()
+
+                    for d, vid, t in zip(distance.cpu().numpy(), filepath, time):
+                        predictions.append((vid, t, d))
+
+        predictions = pd.DataFrame(
+            predictions,
+            columns=["filepath", "time", "distance"],
+        )
+
+        logger.info("Processing output.")
+        # post process to add nans for frames where no animal was detected
+        videos = list(test_dataset.cached_frames.keys())
+        lengths = [np.arange(test_dataset.cached_frames[v]["video_length"]) for v in videos]
+
+        # create one row per frame for duration of video
+        df = pd.Series(index=videos, data=lengths).explode().to_frame().reset_index()
+        df.columns = ["filepath", "time"]
+
+        # merge in predictions
+        output = df.merge(predictions, on=["filepath", "time"], how="outer")
+        return output

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -95,10 +95,10 @@ class DepthDataset(torch.utils.data.Dataset):
                                     (self.height, self.width, self.channels), dtype=int
                                 )
 
-                            # put channels first, resize, divide by 255
-                            selected_frame = transform(torch.tensor(selected_frame)).numpy()
-
-                            cached_frames[video_filepath][f"frame_{i}"] = selected_frame
+                            # transform puts channels first, resizes, divides by 255
+                            cached_frames[video_filepath][f"frame_{i}"] = transform(
+                                torch.tensor(selected_frame)
+                            ).numpy()
 
                     # iterate over detections in frame to create universal detection ID
                     for i, (detection, score) in enumerate(zip(detections, scores)):

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from zamba.data.video import load_video_frames
 from zamba.models.utils import RegionEnum, download_weights
 from zamba.object_detection.yolox.megadetector_lite_yolox import MegadetectorLiteYoloX
-from zamba.pytorch.transforms import ConvertHWCtoCHW, Uint8ToFloat
+from zamba.pytorch.transforms import ConvertHWCtoCHW
 
 
 MODELS = dict(

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -135,7 +135,7 @@ class DepthDataset(torch.utils.data.Dataset):
         # set up input array of frames within window of detection
         # frames are stacked channel-wise
         input = np.concatenate(
-            [self.cached_frames[det_video][f"frame_{det_frame + i}"] for i in self.order],
+            [self.cached_frames[det_video][f"frame_{det_frame + i}"] for i in self.order]
         )
 
         tensor = torch.from_numpy(input)
@@ -232,10 +232,9 @@ class DepthEstimationManager:
                     for d, vid, t in zip(distance.cpu().numpy(), filepath, time):
                         predictions.append((vid, t, d))
 
-        predictions = pd.DataFrame(
-            predictions,
-            columns=["filepath", "time", "distance"],
-        )
+        predictions = pd.DataFrame(predictions, columns=["filepath", "time", "distance"],).round(
+            {"distance": 4}
+        )  # round to useful number of decimal places
 
         logger.info("Processing output.")
         # post process to add nans for frames where no animal was detected

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -135,15 +135,6 @@ class DepthDataset(torch.utils.data.Dataset):
         # set up input array of frames within window of detection
         # frames are stacked channel-wise
         input = np.concatenate(
-            [
-                self.cached_frames[det_video][f"frame_{frame_idx}"]
-                for frame_idx in range(
-                    det_frame - self.window_size, det_frame + self.window_size + 1
-                )
-            ]
-        )
-
-        input = np.concatenate(
             [self.cached_frames[det_video][f"frame_{det_frame + i}"] for i in self.order],
         )
 

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -1,4 +1,3 @@
-from PIL import Image
 from loguru import logger
 import numpy as np
 import pandas as pd

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -241,4 +241,7 @@ class DepthEstimationManager:
         # merge in predictions
         if len(predictions) > 0:
             output = output.merge(predictions, on=["filepath", "time"], how="outer")
+        else:
+            # create empty distance column
+            output["distance"] = np.nan
         return output

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -47,7 +47,7 @@ class DepthDataset(torch.utils.data.Dataset):
             logger.debug(f"Loading video: {video_filepath}")
             try:
                 arr = load_video_frames(video_filepath, fps=1)
-            except:
+            except:  # noqa: E722
                 logger.warning(f"Video {video_filepath} could not be loaded. Skipping.")
                 continue
 
@@ -78,7 +78,7 @@ class DepthDataset(torch.utils.data.Dataset):
                                     # PIL expects size to be (w, h)
                                     Image.fromarray(arr[i]).resize((self.width, self.height))
                                 )
-                            except:
+                            except:  # noqa: E722
                                 selected_frame = np.zeros((self.height, self.width, self.channels))
 
                             cached_frames[video_filepath][f"frame_{i}"] = selected_frame

--- a/zamba/models/depth_estimation/depth_manager.py
+++ b/zamba/models/depth_estimation/depth_manager.py
@@ -30,11 +30,13 @@ def normalize(img):
 class DepthDataset(torch.utils.data.Dataset):
     def __init__(self, filepaths):
 
+        # these are hardcoded because they depend on the trained model weights used for inference
         self.height = 270
         self.width = 480
         self.channels = 3
         self.window_size = 2
         self.num_frames = self.window_size * 2 + 1
+        self.fps = 1
 
         mdlite = MegadetectorLiteYoloX()
         cached_frames = dict()
@@ -46,7 +48,7 @@ class DepthDataset(torch.utils.data.Dataset):
             # get video array at 1 fps, use full size for detecting objects
             logger.debug(f"Loading video: {video_filepath}")
             try:
-                arr = load_video_frames(video_filepath, fps=1)
+                arr = load_video_frames(video_filepath, fps=self.fps)
             except:  # noqa: E722
                 logger.warning(f"Video {video_filepath} could not be loaded. Skipping.")
                 continue
@@ -105,8 +107,8 @@ class DepthDataset(torch.utils.data.Dataset):
         return len(self.detection_indices)
 
     def __getitem__(self, index):
-        """Given the index of the target image, returns a tuple of the stacked image array, the image
-        filename stem, and the time into the video for the target image.
+        """Given a detection index, returns a tuple containing the tensor of stacked frames,
+        video filename, and time into the video for the target frame.
         """
 
         # get detection info

--- a/zamba/models/publish_models.py
+++ b/zamba/models/publish_models.py
@@ -39,7 +39,7 @@ def get_model_only_params(full_configuration, subset="train_config"):
         ]:
             try:
                 config.pop(key)
-            except:
+            except:  # noqa: E722
                 continue
 
     elif subset == "video_loader_config":

--- a/zamba/models/publish_models.py
+++ b/zamba/models/publish_models.py
@@ -10,6 +10,7 @@ import yaml
 from zamba import MODELS_DIRECTORY
 from zamba.models.config import WEIGHT_LOOKUP, ModelEnum
 from zamba.models.densepose import MODELS as DENSEPOSE_MODELS
+from zamba.models.depth_estimation import MODELS as DEPTH_MODELS
 
 
 def get_model_only_params(full_configuration, subset="train_config"):
@@ -34,8 +35,12 @@ def get_model_only_params(full_configuration, subset="train_config"):
             "from_scratch",
             "model_cache_dir",
             "use_default_model_labels",
+            "predict_all_zamba_species",
         ]:
-            config.pop(key)
+            try:
+                config.pop(key)
+            except:
+                continue
 
     elif subset == "video_loader_config":
         config = full_configuration[subset]
@@ -147,6 +152,11 @@ if __name__ == "__main__":
         private_checkpoint = WEIGHT_LOOKUP[model_name]
         logger.info(f"\n============\nPreparing {model_name} model\n============")
         publish_model(model_name, private_checkpoint)
+
+    for name, model in DEPTH_MODELS.items():
+        logger.info(f"\n============\nPreparing {name} model\n============")
+        # upload to the zamba buckets, renaming to model["weights"]
+        upload_to_all_public_buckets(S3Path(model["private_weights_url"]), model["weights"])
 
     for name, model in DENSEPOSE_MODELS.items():
         logger.info(f"\n============\nPreparing DensePose model: {name}\n============")

--- a/zamba/pytorch/transforms.py
+++ b/zamba/pytorch/transforms.py
@@ -27,6 +27,13 @@ class ConvertTCHWtoCTHW(torch.nn.Module):
         return vid.permute(1, 0, 2, 3)
 
 
+class ConvertHWCtoCHW(torch.nn.Module):
+    """Convert tensor from (0:T, 1:H, 2:W, 3:C) to (3:C, 0:T, 1:H, 2:W)"""
+
+    def forward(self, vid: torch.Tensor) -> torch.Tensor:
+        return vid.permute(2, 0, 1)
+
+
 class Uint8ToFloat(torch.nn.Module):
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         return tensor / 255.0

--- a/zamba/pytorch/transforms.py
+++ b/zamba/pytorch/transforms.py
@@ -28,7 +28,7 @@ class ConvertTCHWtoCTHW(torch.nn.Module):
 
 
 class ConvertHWCtoCHW(torch.nn.Module):
-    """Convert tensor from (0:T, 1:H, 2:W, 3:C) to (3:C, 0:T, 1:H, 2:W)"""
+    """Convert tensor from (0:H, 1:W, 2:C) to (2:C, 0:H, 1:W)"""
 
     def forward(self, vid: torch.Tensor) -> torch.Tensor:
         return vid.permute(2, 0, 1)


### PR DESCRIPTION
This implementation takes in a folder of videos (or csv with video filepaths) and outputs a csv of distance estimates for each frame (and detection). 

For frames with no detection, distance is null. If there are multiple detections in that frame, there is one line per detection. For example

```
filepath,time,distance
tests/assets/videos/data/raw/goualougo_2013/gorillas_2013/MPI_FID_20_Duboscia/14-Jun-2013/FID_20_Duboscia_2013-6-14_0083.AVI,0,7.4
tests/assets/videos/data/raw/goualougo_2013/gorillas_2013/MPI_FID_20_Duboscia/14-Jun-2013/FID_20_Duboscia_2013-6-14_0083.AVI,0,7.4
tests/assets/videos/data/raw/goualougo_2013/gorillas_2013/MPI_FID_20_Duboscia/14-Jun-2013/FID_20_Duboscia_2013-6-14_0083.AVI,1,
tests/assets/videos/data/raw/goualougo_2013/gorillas_2013/MPI_FID_20_Duboscia/14-Jun-2013/FID_20_Duboscia_2013-6-14_0083.AVI,2,
tests/assets/videos/data/raw/goualougo_2013/gorillas_2013/MPI_FID_20_Duboscia/14-Jun-2013/FID_20_Duboscia_2013-6-14_0083.AVI,3,
```

Not included in this PR:
- Masking out other detections where there is more than 1. Under the current implementation, if there are two detections in the frame, the distance estimate will be the same for both detections (since the same input is used for both). This allows us to capture the number of detections in the frame, but not differential distances.

Notes:
- In the original implementation, there was a bug where the order of the first two frames were swapped: [-1, -2, 0, 1, 2]. This bug is maintained to match what the model expects

Closes https://github.com/drivendataorg/pjmf-zamba/issues/57

Remaining to do:
- [x] update docs home page to include depth model (and update CLI output)