### PR TITLE
Updates for PyTorch Lightning 2.0 release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Visit https://zamba.drivendata.org/docs/ for full documentation and tutorials.
 
 First, make sure you have the prerequisites installed:
 
-* Python 3.7 or 3.8
+* Python 3.8 or 3.9
 * FFmpeg > 4.3
 
 Then run:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ We encourage people to share their custom models trained with Zamba. If you trai
 
 First, make sure you have the prerequisites installed:
 
-* Python 3.7 or 3.8
+* Python 3.8 or 3.9
 * FFmpeg > 4.3
 
 Then run:

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -9,10 +9,10 @@ GPU configurations.
 
 Prerequisites:
 
- - Python 3.7 or 3.8
+ - Python 3.8 or 3.9
  - FFmpeg
 
-#### [Python](https://www.python.org/) 3.7 or 3.8
+#### [Python](https://www.python.org/) 3.8 or 3.9
 
 We recommend [Python installation using Anaconda](https://www.anaconda.com/download/) for all platforms. For more information about how to install Anaconda, here are some useful YouTube videos of installation:
 

--- a/docs/docs/models/depth.md
+++ b/docs/docs/models/depth.md
@@ -23,7 +23,7 @@ The output of the depth estimation model is a csv with the following columns:
 - `time`: seconds from the start of the video
 - `distance`: distance between detected animal and the camera
 
-There will be multiple rows per timestamp if there are multiple animals detected in the frame. If there is no animal in the frame, the distance will be null.
+There will be multiple rows per timestamp if there are multiple animals detected in the frame. Due to current limitations of the algorithm, the distance for all animals in the frame will be the same. If there is no animal in the frame, the distance will be null.
 
 For example, the first few rows of the `depth_predictions.csv` might look like this:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
   "appdirs",
   "av",
@@ -25,7 +25,6 @@ dependencies = [
   "future",
   "fvcore",
   "gitpython",
-  "importlib_metadata ; python_version < '3.8'",
   "loguru",
   "numpy",
   "opencv-python-headless",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "pqdm",
   "pydantic",
   "python-dotenv",
-  "pytorch-lightning>=1.6.0",
+  "pytorch-lightning>=2.0.0",
   "pytorchvideo",
   "scikit-learn",
   "tensorboard",

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -289,7 +289,7 @@ def train_model(
         callbacks=callbacks,
         fast_dev_run=train_config.dry_run,
         strategy=DDPStrategy(find_unused_parameters=False)
-        if (data_module.multiprocessing_context is not None) and (train_config.gpus > 0)
+        if (data_module.multiprocessing_context is not None) and (train_config.gpus > 1)
         else "auto",
     )
 

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -289,7 +289,7 @@ def train_model(
         callbacks=callbacks,
         fast_dev_run=train_config.dry_run,
         strategy=DDPStrategy(find_unused_parameters=False)
-        if data_module.multiprocessing_context is not None
+        if (data_module.multiprocessing_context is not None) and (train_config.gpus > 0)
         else "auto",
     )
 

--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -13,6 +13,7 @@ import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.strategies import DDPStrategy
+from pytorch_lightning.tuner import Tuner
 
 from zamba.data.video import VideoLoaderConfig
 from zamba.models.config import (
@@ -284,7 +285,6 @@ def train_model(
         accelerator=accelerator,
         devices=devices,
         max_epochs=train_config.max_epochs,
-        auto_lr_find=train_config.auto_lr_find,
         logger=tensorboard_logger,
         callbacks=callbacks,
         fast_dev_run=train_config.dry_run,
@@ -300,7 +300,8 @@ def train_model(
 
     if train_config.auto_lr_find:
         logger.info("Finding best learning rate.")
-        trainer.tune(model, data_module)
+        tuner = Tuner(trainer)
+        tuner.lr_find(model=model, datamodule=data_module)
 
     try:
         git_hash = git.Repo(search_parent_directories=True).head.object.hexsha

--- a/zamba/models/utils.py
+++ b/zamba/models/utils.py
@@ -75,3 +75,14 @@ def get_model_species(checkpoint, model_name):
     else:
         model_species = get_default_hparams(model_name)["species"]
     return model_species
+
+
+def configure_accelerator_and_devices_from_gpus(gpus):
+    """Derive accelerator and number of devices for pl.Trainer from user-specified number of gpus."""
+    if gpus > 0:
+        accelerator = "gpu"
+        devices = gpus
+    else:
+        accelerator = "cpu"
+        devices = "auto"
+    return accelerator, devices


### PR DESCRIPTION
### Configure accelerator and devices for Trainer
Updates how we set the accelerator and devices based on recent PyTorch Lightning changes.

[`pl.Trainer`](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.trainer.trainer.Trainer.html#lightning.pytorch.trainer.trainer.Trainer) now accepts `accelerator` ("cpu", "gpu", etc."), `strategy`, and `devices` params instead of `num_gpus`. This PR adds a utility to configure accelerator and devices based on the number of user-specified gpus. 

Pros:
- keeps the command line to the same limited set of options (e.g. just specifying number of gpus instead of exposing both the cpu/gpu option as well as number of devices/cores)
- allows us to validate user-provided input up front to ensure that training won't fail after the long video loading check

Cons
- doesn't allow the user to specify the number of cores; if a GPU is not used, all cores will be used
- doesn't support the new "mps" accelerator for apple silicon

Relevant links:
- [GPU training](https://lightning.ai/docs/pytorch/stable/accelerators/gpu_basic.html)
- [Trainer docs](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.trainer.trainer.Trainer.html#lightning.pytorch.trainer.trainer.Trainer)
- [About strategies](https://lightning.ai/docs/pytorch/stable/extensions/strategy.html)

Closes #264 
Closes #265 

### Other changes based on PTL 2.0 release

The new PTL release makes a bunch of non-backward compatible API changes. This PR also provides fixes for those and sets 2.0 as the floor.

- modifies the syntax for learning rate finding with the separation of `Trainer` and `Tuner` (https://github.com/Lightning-AI/lightning/pull/16462)
- updates epoch end hook names and outputs per https://github.com/Lightning-AI/lightning/pull/16520
- removes python 3.7 which isn't compatible with lightning 2.0

### Bonus fixes
- adds a note in the depth estimation docs about the limitations for multiple individuals in the frame (which came up in a user email)
- only use DDP strategy for multi-gpu; this removes a bunch of unnecessary logging warnings about metric syncing across devices which arose from using DDP on a single GPU; we can take advantage of the new "auto" strategy in PTL 2.0
