### PR TITLE
Use concat instead of append for pandas 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "numpy",
   "opencv-python-headless",
   "openpyxl",
-  "pandas>1.2.0",
+  "pandas>=2.0.0",
   "pandas_path",
   "pqdm",
   "pydantic",


### PR DESCRIPTION
In [pandas 2.0.0](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html), the `.append` method got deprecated. The guidance is to use [`.concat`](https://pandas.pydata.org/docs/dev/reference/api/pandas.concat.html#pandas.concat) instead. This PR makes those updates. This only impacts our tests.