### PR TITLE
Add maximize-build-space step

### DIFF
--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,21 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 30000  # for pip packages in /tmp
+          remove-dotnet: true
+          remove-android: true
+
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           cache: 'pip'
@@ -69,7 +69,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -119,7 +119,7 @@ jobs:
           version: "4.4"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
         name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 10240  # for pip packages in /tmp
+          root-reserve-mb: 15000  # for pip packages in /tmp
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,8 @@ jobs:
         name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 15000  # for pip packages in /tmp
+          root-reserve-mb: 20000  # for pip packages in /tmp
+          remove-dotnet: true
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: 3.8
           cache: 'pip'
+          cache-dependency-path: requirements-dev/lint.txt
 
       - name: Install dependencies
         run: |
@@ -70,6 +71,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -119,6 +121,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -48,6 +49,8 @@ jobs:
       - if: matrix.os == 'ubuntu-latest'
         name: Maximize build space
         uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 10240  # for pip packages in /tmp
 
       - uses: actions/checkout@v2
 
@@ -66,6 +69,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -114,6 +118,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,10 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-      - name: Maximize build space
+      - if: matrix.os == 'ubuntu-latest'
+        name: Maximize build space
         uses: easimon/maximize-build-space@master
+
       - uses: actions/checkout@v2
 
       - name: Setup FFmpeg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,9 @@ jobs:
         name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 20000  # for pip packages in /tmp
+          root-reserve-mb: 30000  # for pip packages in /tmp
           remove-dotnet: true
+          remove-android: true
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
       - uses: actions/checkout@v2
 
       - name: Setup FFmpeg


### PR DESCRIPTION
Adds the `maximize-build-space` action:
https://github.com/easimon/maximize-build-space

This removes extra software on the runner and re-allocates space to the runners working directory.

`root-reserve-mb` - Saves space on the root of the file system rather than allocating it all to the local running directory (e.g., anything saved to temp dirs). Needed to balance the pip installs and weight downloads, which go to temp dirs.

More software can be removed if necessary, it just makes each run take longer. See this table for which packages can be removed and how much space you get:
https://github.com/easimon/maximize-build-space/blob/test-report/README.md


