### PR TITLE
More space for build and install step in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,13 @@ jobs:
         python-version: [3.8]
 
     steps:
+      name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 30000  # for pip packages in /tmp
+          remove-dotnet: true
+          remove-android: true
+
       - uses: actions/checkout@v2
 
       - name: Setup FFmpeg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-      name: Maximize build space
+      - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
           root-reserve-mb: 30000  # for pip packages in /tmp


### PR DESCRIPTION
Tests are failing because the test for installation runs out of space:
https://github.com/drivendataorg/zamba/actions/runs/6366532961

Closes #293 
Closes #292 