### PR TITLE
Use uv for CI

### DIFF
--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -11,17 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Python and uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: 3.8
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev/docs.txt
+          uv pip install -r requirements-dev/docs.txt
 
       - name: Build documentation
         run: |

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -9,17 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Python and uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: 3.8
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev/docs.txt
+          uv pip install -r requirements-dev/docs.txt
 
       - name: Build documentation
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,20 +18,17 @@ jobs:
           remove-dotnet: true
           remove-android: true
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Python and uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: 3.8
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev/docs.txt
-          pip install -e .
+          uv pip install -r requirements-dev/docs.txt
+          uv pip install -e .
 
       - name: Check that versions match
         id: version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,8 +71,6 @@ jobs:
         uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -86,8 +84,7 @@ jobs:
         env:
           ZAMBA_RUN_DENSEPOSE_TESTS: 1
         run: |
-          # torch is alread installed, so just add the densepose extra
-          uv pip install -e .[tests,densepose]
+          pip install -e .[densepose]
           make densepose-tests
 
       - name: Upload coverage to codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -r requirements-dev.txt
+          uv pip install -r requirements-dev/lint.txt
 
       - name: Lint package
         run: |
@@ -85,6 +85,7 @@ jobs:
           ZAMBA_RUN_DENSEPOSE_TESTS: 1
         run: |
           uv pip install flit-core
+          # torch is alread installed, so just add the densepose extra
           uv pip install -e .[densepose] --no-build-isolation
           make densepose-tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,49 +32,49 @@ jobs:
         run: |
           make lint
 
-  # tests:
-  #   name: Test suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
-  #   needs: code-quality
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     DISTUTILS_USE_SDK: 1 # for MSVC compiler
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, macos-latest]
-  #       python-version: [3.8, 3.9]
+  tests:
+    name: Test suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    needs: code-quality
+    runs-on: ${{ matrix.os }}
+    env:
+      DISTUTILS_USE_SDK: 1 # for MSVC compiler
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.8, 3.9]
 
-  #   steps:
-  #     - if: matrix.os == 'ubuntu-latest'
-  #       name: Maximize build space
-  #       uses: easimon/maximize-build-space@master
-  #       with:
-  #         root-reserve-mb: 32000  # for pip packages in /tmp
-  #         remove-dotnet: true
-  #         remove-android: true
-  #         remove-haskell: true
-  #         remove-codeql: true
+    steps:
+      - if: matrix.os == 'ubuntu-latest'
+        name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 32000  # for pip packages in /tmp
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-codeql: true
 
-  #     - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-  #     - name: Setup FFmpeg
-  #       uses: Iamshankhadeep/setup-ffmpeg@v1.1
-  #       with:
-  #         # Not strictly necessary, but it may prevent rate limit
-  #         # errors especially on GitHub-hosted macos machines.
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         version: "4.4"
+      - name: Setup FFmpeg
+        uses: Iamshankhadeep/setup-ffmpeg@v1.1
+        with:
+          # Not strictly necessary, but it may prevent rate limit
+          # errors especially on GitHub-hosted macos machines.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: "4.4"
 
-  #     - name: Configure Windows compilers
-  #       uses: ilammy/msvc-dev-cmd@v1
+      - name: Configure Windows compilers
+        uses: ilammy/msvc-dev-cmd@v1
 
-  #     - name: Set up Python and uv
-  #       uses: drivendataorg/setup-python-uv-action@v1
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
+      - name: Set up Python and uv
+        uses: drivendataorg/setup-python-uv-action@v1
+        with:
+          python-version: ${{ matrix.python-version }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         uv pip install -e .[tests]
+      - name: Install dependencies
+        run: |
+          uv pip install -e .[tests]
 
   #     - name: Run tests
   #       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,19 +17,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Python and uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: 3.8
-          cache: 'pip'
-          cache-dependency-path: requirements-dev/lint.txt
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev/lint.txt
+          uv pip install -r requirements-dev.txt
 
       - name: Lint package
         run: |
@@ -57,7 +54,7 @@ jobs:
           remove-haskell: true
           remove-codeql: true
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup FFmpeg
         uses: Iamshankhadeep/setup-ffmpeg@v1.1
@@ -70,8 +67,8 @@ jobs:
       - name: Configure Windows compilers
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Set up Python and uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -79,8 +76,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[tests]
+          uv pip install -e .[tests]
 
       - name: Run tests
         run: |
@@ -128,19 +124,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: "4.4"
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Set up Python and uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
 
       - name: Build package
         run: |
+          uv pip install build
           make dist
 
       - name: Install wheel; test CLI + models with assets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           ZAMBA_RUN_DENSEPOSE_TESTS: 1
         run: |
+          uv pip install flit-core
           uv pip install -e .[densepose] --no-build-isolation
           make densepose-tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,69 +32,69 @@ jobs:
         run: |
           make lint
 
-  tests:
-    name: Test suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
-    needs: code-quality
-    runs-on: ${{ matrix.os }}
-    env:
-      DISTUTILS_USE_SDK: 1 # for MSVC compiler
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+  # tests:
+  #   name: Test suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
+  #   needs: code-quality
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     DISTUTILS_USE_SDK: 1 # for MSVC compiler
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, macos-latest]
+  #       python-version: [3.8, 3.9]
 
-    steps:
-      - if: matrix.os == 'ubuntu-latest'
-        name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 32000  # for pip packages in /tmp
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
+  #   steps:
+  #     - if: matrix.os == 'ubuntu-latest'
+  #       name: Maximize build space
+  #       uses: easimon/maximize-build-space@master
+  #       with:
+  #         root-reserve-mb: 32000  # for pip packages in /tmp
+  #         remove-dotnet: true
+  #         remove-android: true
+  #         remove-haskell: true
+  #         remove-codeql: true
 
-      - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v4
 
-      - name: Setup FFmpeg
-        uses: Iamshankhadeep/setup-ffmpeg@v1.1
-        with:
-          # Not strictly necessary, but it may prevent rate limit
-          # errors especially on GitHub-hosted macos machines.
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: "4.4"
+  #     - name: Setup FFmpeg
+  #       uses: Iamshankhadeep/setup-ffmpeg@v1.1
+  #       with:
+  #         # Not strictly necessary, but it may prevent rate limit
+  #         # errors especially on GitHub-hosted macos machines.
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         version: "4.4"
 
-      - name: Configure Windows compilers
-        uses: ilammy/msvc-dev-cmd@v1
+  #     - name: Configure Windows compilers
+  #       uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Set up Python and uv
-        uses: drivendataorg/setup-python-uv-action@v1
-        with:
-          python-version: ${{ matrix.python-version }}
+  #     - name: Set up Python and uv
+  #       uses: drivendataorg/setup-python-uv-action@v1
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: |
-          uv pip install -e .[tests]
+  #     - name: Install dependencies
+  #       run: |
+  #         uv pip install -e .[tests]
 
-      - name: Run tests
-        run: |
-          make tests
+  #     - name: Run tests
+  #       run: |
+  #         make tests
 
-      - name: Run densepose tests
-        env:
-          ZAMBA_RUN_DENSEPOSE_TESTS: 1
-        run: |
-          uv pip install flit-core
-          # torch is alread installed, so just add the densepose extra
-          uv pip install -e .[densepose] --no-build-isolation
-          make densepose-tests
+  #     - name: Run densepose tests
+  #       env:
+  #         ZAMBA_RUN_DENSEPOSE_TESTS: 1
+  #       run: |
+  #         uv pip install flit-core
+  #         # torch is alread installed, so just add the densepose extra
+  #         uv pip install -e .[densepose] --no-build-isolation
+  #         make densepose-tests
 
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          fail_ci_if_error: true
+  #     - name: Upload coverage to codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         token: ${{ secrets.CODECOV_TOKEN }}
+  #         file: ./coverage.xml
+  #         fail_ci_if_error: true
 
   test-install:
     name: Test install from built distributions
@@ -135,20 +135,15 @@ jobs:
 
       - name: Install wheel; test CLI + models with assets
         run: |
-          uv venv .venv-whl
-          source .venv-whl/bin/activate
-          PYTHON_BIN=bin/python
-          uv pip install dist/zamba-*.whl
-          .venv-whl/$PYTHON_BIN -m zamba --help
-          .venv-whl/$PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
+          uv pip install zamba@$(find dist -name 'zamba*.whl') --no-deps --force-reinstall
+          python -m zamba --help
+          python -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
       - name: Install source; test CLI + models with assets
         run: |
-          uv venv .venv-sdist
-          PYTHON_BIN=bin/python
-          uv pip install dist/zamba-*.tar.gz
-          .venv-sdist/$PYTHON_BIN -m zamba --help
-          .venv-sdist/$PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
+          uv pip install zamba@$(find dist -name 'zamba*.tar.gz') --no-deps --force-reinstall
+          python -m zamba --help
+          python -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
   notify:
     name: Notify failed build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,8 @@ jobs:
         env:
           ZAMBA_RUN_DENSEPOSE_TESTS: 1
         run: |
+          which pip
+          uv pip install pip
           pip install -e .[densepose]
           make densepose-tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 30000  # for pip packages in /tmp
+          root-reserve-mb: 32000  # for pip packages in /tmp
           remove-dotnet: true
           remove-android: true
           remove-haskell: true
@@ -84,7 +84,6 @@ jobs:
         env:
           ZAMBA_RUN_DENSEPOSE_TESTS: 1
         run: |
-          which pip
           uv pip install pip
           pip install -e .[densepose]
           make densepose-tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
           ZAMBA_RUN_DENSEPOSE_TESTS: 1
         run: |
           # torch is alread installed, so just add the densepose extra
-          pip install -e .[tests,densepose]
+          uv pip install -e .[tests,densepose]
           make densepose-tests
 
       - name: Upload coverage to codecov
@@ -136,19 +136,18 @@ jobs:
 
       - name: Install wheel; test CLI + models with assets
         run: |
-          python -m venv .venv-whl
+          uv venv .venv-whl
+          source .venv-whl/bin/activate
           PYTHON_BIN=bin/python
-          .venv-whl/$PYTHON_BIN -m pip install --upgrade pip
-          .venv-whl/$PYTHON_BIN -m pip install dist/zamba-*.whl
+          uv pip install dist/zamba-*.whl
           .venv-whl/$PYTHON_BIN -m zamba --help
           .venv-whl/$PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
       - name: Install source; test CLI + models with assets
         run: |
-          python -m venv .venv-sdist
+          uv venv .venv-sdist
           PYTHON_BIN=bin/python
-          .venv-sdist/$PYTHON_BIN -m pip install --upgrade pip
-          .venv-sdist/$PYTHON_BIN -m pip install dist/zamba-*.tar.gz
+          uv pip install dist/zamba-*.tar.gz
           .venv-sdist/$PYTHON_BIN -m zamba --help
           .venv-sdist/$PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 25000  # for pip packages in /tmp
+          root-reserve-mb: 30000  # for pip packages in /tmp
           remove-dotnet: true
           remove-android: true
           remove-haskell: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,49 +32,49 @@ jobs:
         run: |
           make lint
 
-  tests:
-    name: Test suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
-    needs: code-quality
-    runs-on: ${{ matrix.os }}
-    env:
-      DISTUTILS_USE_SDK: 1 # for MSVC compiler
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+  # tests:
+  #   name: Test suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
+  #   needs: code-quality
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     DISTUTILS_USE_SDK: 1 # for MSVC compiler
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, macos-latest]
+  #       python-version: [3.8, 3.9]
 
-    steps:
-      - if: matrix.os == 'ubuntu-latest'
-        name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 32000  # for pip packages in /tmp
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
+  #   steps:
+  #     - if: matrix.os == 'ubuntu-latest'
+  #       name: Maximize build space
+  #       uses: easimon/maximize-build-space@master
+  #       with:
+  #         root-reserve-mb: 32000  # for pip packages in /tmp
+  #         remove-dotnet: true
+  #         remove-android: true
+  #         remove-haskell: true
+  #         remove-codeql: true
 
-      - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v4
 
-      - name: Setup FFmpeg
-        uses: Iamshankhadeep/setup-ffmpeg@v1.1
-        with:
-          # Not strictly necessary, but it may prevent rate limit
-          # errors especially on GitHub-hosted macos machines.
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: "4.4"
+  #     - name: Setup FFmpeg
+  #       uses: Iamshankhadeep/setup-ffmpeg@v1.1
+  #       with:
+  #         # Not strictly necessary, but it may prevent rate limit
+  #         # errors especially on GitHub-hosted macos machines.
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         version: "4.4"
 
-      - name: Configure Windows compilers
-        uses: ilammy/msvc-dev-cmd@v1
+  #     - name: Configure Windows compilers
+  #       uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Set up Python and uv
-        uses: drivendataorg/setup-python-uv-action@v1
-        with:
-          python-version: ${{ matrix.python-version }}
+  #     - name: Set up Python and uv
+  #       uses: drivendataorg/setup-python-uv-action@v1
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: |
-          uv pip install -e .[tests]
+  #     - name: Install dependencies
+  #       run: |
+  #         uv pip install -e .[tests]
 
   #     - name: Run tests
   #       run: |
@@ -98,7 +98,7 @@ jobs:
 
   test-install:
     name: Test install from built distributions
-    needs: tests
+    # needs: tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -135,15 +135,19 @@ jobs:
 
       - name: Install wheel; test CLI + models with assets
         run: |
-          uv pip install zamba@$(find dist -name 'zamba*.whl') --no-deps --force-reinstall
-          python -m zamba --help
-          python -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
+          uv venv .venv-whl
+          PYTHON_BIN=.venv-whl/bin/python
+          uv pip install --python=$PYTHON_BIN zamba@$(find dist -name 'zamba*.whl') --force-reinstall
+          $PYTHON_BIN -m zamba --help
+          $PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
       - name: Install source; test CLI + models with assets
         run: |
-          uv pip install zamba@$(find dist -name 'zamba*.tar.gz') --no-deps --force-reinstall
-          python -m zamba --help
-          python -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
+          uv venv .venv-sdist
+          PYTHON_BIN=.venv-sdist/bin/python
+          uv pip install --python=$PYTHON_BIN zamba@$(find dist -name 'zamba*.tar.gz') --force-reinstall
+          $PYTHON_BIN -m zamba --help
+          $PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
   notify:
     name: Notify failed build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,19 +135,21 @@ jobs:
 
       - name: Install wheel; test CLI + models with assets
         run: |
-          uv venv .venv-whl
-          PYTHON_BIN=.venv-whl/bin/python
-          uv pip install --python=$PYTHON_BIN zamba@$(find dist -name 'zamba*.whl') --force-reinstall
-          $PYTHON_BIN -m zamba --help
-          $PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
+          python -m venv .venv-whl
+          PYTHON_BIN=bin/python
+          .venv-whl/$PYTHON_BIN -m pip install --upgrade pip
+          .venv-whl/$PYTHON_BIN -m pip install dist/zamba-*.whl
+          .venv-whl/$PYTHON_BIN -m zamba --help
+          .venv-whl/$PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
       - name: Install source; test CLI + models with assets
         run: |
-          uv venv .venv-sdist
-          PYTHON_BIN=.venv-sdist/bin/python
-          uv pip install --python=$PYTHON_BIN zamba@$(find dist -name 'zamba*.tar.gz') --force-reinstall
-          $PYTHON_BIN -m zamba --help
-          $PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
+          python -m venv .venv-sdist
+          PYTHON_BIN=bin/python
+          .venv-sdist/$PYTHON_BIN -m pip install --upgrade pip
+          .venv-sdist/$PYTHON_BIN -m pip install dist/zamba-*.tar.gz
+          .venv-sdist/$PYTHON_BIN -m zamba --help
+          .venv-sdist/$PYTHON_BIN -c "from zamba.data.video import MegadetectorLiteYoloX; MegadetectorLiteYoloX()"
 
   notify:
     name: Notify failed build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 35000  # for pip packages in /tmp
+          root-reserve-mb: 25000  # for pip packages in /tmp
           remove-dotnet: true
           remove-android: true
           remove-haskell: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,8 +84,7 @@ jobs:
         env:
           ZAMBA_RUN_DENSEPOSE_TESTS: 1
         run: |
-          uv pip install pip
-          pip install -e .[densepose]
+          uv pip install -e .[densepose] --no-build-isolation
           make densepose-tests
 
       - name: Upload coverage to codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,73 +32,73 @@ jobs:
         run: |
           make lint
 
-  # tests:
-  #   name: Test suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
-  #   needs: code-quality
-  #   runs-on: ${{ matrix.os }}
-  #   env:
-  #     DISTUTILS_USE_SDK: 1 # for MSVC compiler
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, macos-latest]
-  #       python-version: [3.8, 3.9]
+  tests:
+    name: Test suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    needs: code-quality
+    runs-on: ${{ matrix.os }}
+    env:
+      DISTUTILS_USE_SDK: 1 # for MSVC compiler
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.8, 3.9]
 
-  #   steps:
-  #     - if: matrix.os == 'ubuntu-latest'
-  #       name: Maximize build space
-  #       uses: easimon/maximize-build-space@master
-  #       with:
-  #         root-reserve-mb: 32000  # for pip packages in /tmp
-  #         remove-dotnet: true
-  #         remove-android: true
-  #         remove-haskell: true
-  #         remove-codeql: true
+    steps:
+      - if: matrix.os == 'ubuntu-latest'
+        name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 32000  # for pip packages in /tmp
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-codeql: true
 
-  #     - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-  #     - name: Setup FFmpeg
-  #       uses: Iamshankhadeep/setup-ffmpeg@v1.1
-  #       with:
-  #         # Not strictly necessary, but it may prevent rate limit
-  #         # errors especially on GitHub-hosted macos machines.
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         version: "4.4"
+      - name: Setup FFmpeg
+        uses: Iamshankhadeep/setup-ffmpeg@v1.1
+        with:
+          # Not strictly necessary, but it may prevent rate limit
+          # errors especially on GitHub-hosted macos machines.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: "4.4"
 
-  #     - name: Configure Windows compilers
-  #       uses: ilammy/msvc-dev-cmd@v1
+      - name: Configure Windows compilers
+        uses: ilammy/msvc-dev-cmd@v1
 
-  #     - name: Set up Python and uv
-  #       uses: drivendataorg/setup-python-uv-action@v1
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
+      - name: Set up Python and uv
+        uses: drivendataorg/setup-python-uv-action@v1
+        with:
+          python-version: ${{ matrix.python-version }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         uv pip install -e .[tests]
+      - name: Install dependencies
+        run: |
+          uv pip install -e .[tests]
 
-  #     - name: Run tests
-  #       run: |
-  #         make tests
+      - name: Run tests
+        run: |
+          make tests
 
-  #     - name: Run densepose tests
-  #       env:
-  #         ZAMBA_RUN_DENSEPOSE_TESTS: 1
-  #       run: |
-  #         uv pip install flit-core
-  #         # torch is alread installed, so just add the densepose extra
-  #         uv pip install -e .[densepose] --no-build-isolation
-  #         make densepose-tests
+      - name: Run densepose tests
+        env:
+          ZAMBA_RUN_DENSEPOSE_TESTS: 1
+        run: |
+          uv pip install flit-core
+          # torch is alread installed, so just add the densepose extra
+          uv pip install -e .[densepose] --no-build-isolation
+          make densepose-tests
 
-  #     - name: Upload coverage to codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         token: ${{ secrets.CODECOV_TOKEN }}
-  #         file: ./coverage.xml
-  #         fail_ci_if_error: true
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          fail_ci_if_error: true
 
   test-install:
     name: Test install from built distributions
-    # needs: tests
+    needs: tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -153,7 +153,7 @@ jobs:
 
   notify:
     name: Notify failed build
-    # needs: [code-quality, tests, test-install]
+    needs: [code-quality, tests, test-install]
     if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,7 @@ jobs:
 
   notify:
     name: Notify failed build
-    needs: [code-quality, tests, test-install]
+    # needs: [code-quality, tests, test-install]
     if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ tests = [
 ]
 densepose = [
   "torch<2.1.0",  # densepose broken after 2.1.0; https://github.com/facebookresearch/detectron2/issues/5110
+  "detectron2 @ git+https://github.com/facebookresearch/detectron2.git",
   "detectron2-densepose @ git+https://github.com/facebookresearch/detectron2@main#subdirectory=projects/DensePose"
 ]
 


### PR DESCRIPTION
Swaps in [drivendataorg/setup-python-uv-action](https://github.com/drivendataorg/setup-python-uv-action) and installs our dependencies with uv (without caching).

Closes #312 