### PR TITLE
Surface the basic configuration with the user before proceeding with validation checking - Issue #196

### DIFF
--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -78,6 +78,7 @@ def train(
 
     If an argument is specified in both the command line and in a yaml file, the command line input will take precedence.
     """
+    
     if config is not None:
         with config.open() as f:
             config_dict = yaml.safe_load(f)
@@ -128,6 +129,27 @@ def train(
     if skip_load_validation is not None:
         train_dict["skip_load_validation"] = skip_load_validation
 
+    # surface the configuration before validation checking    
+    msg = f"""Review the following configuration before proceeding with validation checking:
+
+    Config file: {config_file}
+    Data directory: {data_dir if data_dir is not None else config_dict["train_config"].get("data_dir")}
+    Labels csv: {labels if labels is not None else config_dict["train_config"].get("labels")}
+    Checkpoint: {checkpoint if checkpoint is not None else config_dict["train_config"].get("checkpoint")}
+    """
+
+    if yes:
+        typer.echo(f"{msg}\n\nSkipping confirmation and proceeding to validation checking.")
+    else:
+        yes = typer.confirm(
+            f"{msg}\n\nIs this correct?",
+            abort=False,
+            default=True,
+        )
+        if not yes:
+            print("\n\nPlease review and adjust the configuration and run the command again.")
+            return
+    
     try:
         manager = ModelManager(
             ModelConfig(
@@ -320,6 +342,27 @@ def predict(
 
     if overwrite is not None:
         predict_dict["overwrite"] = overwrite
+
+    # surface the configuration before validation checking    
+    msg = f"""Review the following configuration before proceeding with validation checking:
+
+    Config file: {config_file}
+    Data directory: {data_dir if data_dir is not None else config_dict["predict_config"].get("data_dir")}
+    Filepath csv: {filepaths if filepaths is not None else config_dict["predict_config"].get("filepaths")}
+    Checkpoint: {checkpoint if checkpoint is not None else config_dict["predict_config"].get("checkpoint")}
+    """
+
+    if yes:
+        typer.echo(f"{msg}\n\nSkipping confirmation and proceeding to validation checking.")
+    else:
+        yes = typer.confirm(
+            f"{msg}\n\nIs this correct?",
+            abort=False,
+            default=True,
+        )
+        if not yes:
+            print("\n\nPlease review and adjust the configuration and run the command again.")
+            return
 
     try:
         manager = ModelManager(

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -524,11 +524,13 @@ class TrainConfig(ZambaBaseModel):
                 )
 
             elif values["split_proportions"] is not None:
-                logger.warning(
-                    "Labels contains split column yet split_proportions are also provided. Split column in labels takes precedence."
-                )
-                # set to None for clarity in final configuration.yaml
-                values["split_proportions"] = None
+                # Check to see if split_proportions contains the default values
+                if values.get("split_proportions") != {"train": 3, "val": 1, "holdout": 1}: 
+                    logger.warning(
+                        "Labels contains split column yet split_proportions are also provided. Split column in labels takes precedence."
+                    )
+                    # set to None for clarity in final configuration.yaml
+                    values["split_proportions"] = None
 
         # error if labels are entirely null
         null_labels = labels.label.isnull()


### PR DESCRIPTION
Per #196,

@aaronphilip19 and I implemented this by defining the configuration file, data directory, csv file path, and the checkpoint based on user input and default values. We then prompted the user with a message through the command line interface asking them to review the basic configuration. If they answered yes, they would proceed with the validation; if they answered no, they had the option to change whatever they needed and to run the respective command (zamba predict or zamba train) through the terminal again.