### PR TITLE
Set split proportions to None if split column is provided - Issue #198

### DIFF
--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -524,11 +524,13 @@ class TrainConfig(ZambaBaseModel):
                 )
 
             elif values["split_proportions"] is not None:
-                logger.warning(
-                    "Labels contains split column yet split_proportions are also provided. Split column in labels takes precedence."
-                )
-                # set to None for clarity in final configuration.yaml
-                values["split_proportions"] = None
+                # Check to see if split_proportions contains the default values
+                if values.get("split_proportions") != {"train": 3, "val": 1, "holdout": 1}: 
+                    logger.warning(
+                        "Labels contains split column yet split_proportions are also provided. Split column in labels takes precedence."
+                    )
+                    # set to None for clarity in final configuration.yaml
+                    values["split_proportions"] = None
 
         # error if labels are entirely null
         null_labels = labels.label.isnull()


### PR DESCRIPTION
Per #198,

@aaronphilip19 and I implemented this by defining the default split_proporitions values. We then added a check to see if the provided split column is equal to the default values. If they are not equal, “Labels contains split column yet split_proportions are also provided. Split column in labels takes precedence.” is prompted and split_proportions is set to None.