### PR TITLE
Uncouple Multiprocessing settings - Issue#240

### DIFF
--- a/zamba/models/model_manager.py
+++ b/zamba/models/model_manager.py
@@ -280,19 +280,17 @@ def train_model(
 
     accelerator, devices = configure_accelerator_and_devices_from_gpus(train_config.gpus)
 
+
+    multiprocessing_strategy = getattr(train_config,"multiprocessing_strategy",None)
+
     trainer = pl.Trainer(
         accelerator=accelerator,
         devices=devices,
         max_epochs=train_config.max_epochs,
         logger=tensorboard_logger,
-        callbacks=callbacks,
-        fast_dev_run=train_config.dry_run,
-        strategy=(
-            DDPStrategy(find_unused_parameters=False)
-            if (data_module.multiprocessing_context is not None) and (train_config.gpus > 1)
-            else "auto"
-        ),
+        strategy = multiprocessing_strategy,     
     )
+    #Set the strategy within trainer to reflect changes
 
     if video_loader_config.cache_dir is None:
         logger.info("No cache dir is specified. Videos will not be cached.")

--- a/zamba/pytorch_lightning/utils.py
+++ b/zamba/pytorch_lightning/utils.py
@@ -67,7 +67,7 @@ class ZambaDataModule(LightningDataModule):
         )
         self.multiprocessing_context: BaseContext = (
             None
-            if (multiprocessing_context is None) or (num_workers == 0)
+            if (num_workers == 0) or (multiprocessing_context is None)
             else multiprocessing_context
         )
 

--- a/zamba/pytorch_lightning/utils.py
+++ b/zamba/pytorch_lightning/utils.py
@@ -65,11 +65,8 @@ class ZambaDataModule(LightningDataModule):
             transform=transform,
             video_loader_config=video_loader_config,
         )
-        self.multiprocessing_context: BaseContext = (
-            None
-            if (num_workers == 0) or (multiprocessing_context is None)
-            else multiprocessing_context
-        )
+        self.multiprocessing_context: BaseContext = multiprocessing_context #Modified the multiprocessing context to not factor in num_workers decoupliing it
+
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Per #240,

@samujangfofana and I implemented this by separating the base context inference for the multiprocessor for the trainer. We did by setting the base context of multiprocessing_context to not take in num_workers. Update trainer configuration in model_manager to take in multiprocessing strategy.