### PR TITLE
Replace maximize-build-space action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,18 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 30000  # for pip packages in /tmp
-          remove-dotnet: true
-          remove-android: true
+      - name: Remove unused software
+        run:
+          echo "Available storage before:"
+          sudo df -h
+          echo
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          echo "Available storage after:"
+          sudo df -h
+          echo
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Remove unused software
-        run:
+        run: |
           echo "Available storage before:"
           sudo df -h
           echo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,14 +45,18 @@ jobs:
 
     steps:
       - if: matrix.os == 'ubuntu-latest'
-        name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 32000  # for pip packages in /tmp
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
+        name: Remove unused software
+        run:
+          echo "Available storage before:"
+          sudo df -h
+          echo
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          echo "Available storage after:"
+          sudo df -h
+          echo
 
       - uses: actions/checkout@v4
 
@@ -118,12 +122,18 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 30000  # for pip packages in /tmp
-          remove-dotnet: true
-          remove-android: true
+      - name: Remove unused software
+        run:
+          echo "Available storage before:"
+          sudo df -h
+          echo
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          echo "Available storage after:"
+          sudo df -h
+          echo
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - if: matrix.os == 'ubuntu-latest'
         name: Remove unused software
-        run:
+        run: |
           echo "Available storage before:"
           sudo df -h
           echo
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Remove unused software
-        run:
+        run: |
           echo "Available storage before:"
           sudo df -h
           echo


### PR DESCRIPTION
The [easimon/maximize-build-space](https://github.com/easimon/maximize-build-space/) action is a victim of GitHub changing stuff about how the runners are set up. A lot of the functionality is broken, and this affects us because `root-reserve-mb` doesn't work anymore. 

- https://github.com/easimon/maximize-build-space/issues/44
- https://github.com/easimon/maximize-build-space/issues/48

This PR replaces the action with some `sudo rm -rf` commands that just duplicate what the action was doing for the parts where it deletes unwanted software. 