### PR TITLE
Upgrade the required python version to python>=3.11

### DIFF
--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python and uv
         uses: drivendataorg/setup-python-uv-action@v1
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python and uv
         uses: drivendataorg/setup-python-uv-action@v1
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python and uv
         uses: drivendataorg/setup-python-uv-action@v1
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.11]
+        python-version: [3.11, 3.12]
 
     steps:
       - if: matrix.os == 'ubuntu-latest'
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.11]
+        python-version: [3.11, 3.12]
 
     steps:
       - name: Remove unused software

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python and uv
         uses: drivendataorg/setup-python-uv-action@v1
         with:
-          python-version: [3.11]
+          python-version: 3.11
 
       - name: Install dependencies
         run: |
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.11]
+        python-version: 3.11
 
     steps:
       - name: Remove unused software

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
           make densepose-tests
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: 3.11
+        python-version: [3.11]
 
     steps:
       - name: Remove unused software

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
           ZAMBA_RUN_DENSEPOSE_TESTS: 1
         run: |
           uv pip install flit-core
-          # torch is alread installed, so just add the densepose extra
+          # torch is already installed, so just add the densepose extra
           uv pip install -e .[densepose] --no-build-isolation
           make densepose-tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python and uv
         uses: drivendataorg/setup-python-uv-action@v1
         with:
-          python-version: 3.8
+          python-version: [3.11]
 
       - name: Install dependencies
         run: |
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.11, 3.12]
 
     steps:
       - if: matrix.os == 'ubuntu-latest'
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.11]
 
     steps:
       - name: Remove unused software

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.11, 3.12]
+        python-version: [3.11]
 
     steps:
       - if: matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 PROJECT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 PROJECT_NAME = zamba
-PYTHON_VERSION = 3.8
+PYTHON_VERSION = 3.11
 PYTHON_INTERPRETER = python
 
 ifeq (, $(shell which nvidia-smi))

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Visit https://zamba.drivendata.org/docs/ for full documentation and tutorials.
 
 First, make sure you have the prerequisites installed:
 
-* Python 3.8 or 3.9
+* Python >= 3.10
 * FFmpeg > 4.3
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Visit https://zamba.drivendata.org/docs/ for full documentation and tutorials.
 
 First, make sure you have the prerequisites installed:
 
-* Python >= 3.10
+* Python >= 3.11
 * FFmpeg > 4.3
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Visit https://zamba.drivendata.org/docs/ for full documentation and tutorials.
 
 First, make sure you have the prerequisites installed:
 
-* Python >= 3.11
+* Python 3.11 or 3.12
 * FFmpeg > 4.3
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Visit https://zamba.drivendata.org/docs/ for full documentation and tutorials.
 
 First, make sure you have the prerequisites installed:
 
-* Python 3.11
+* Python 3.11 or 3.12
 * FFmpeg > 4.3
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Visit https://zamba.drivendata.org/docs/ for full documentation and tutorials.
 
 First, make sure you have the prerequisites installed:
 
-* Python 3.11 or 3.12
+* Python 3.11
 * FFmpeg > 4.3
 
 Then run:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ We encourage people to share their custom models trained with Zamba. If you trai
 
 First, make sure you have the prerequisites installed:
 
-* Python 3.11
+* Python 3.11 or 3.12
 * FFmpeg > 4.3
 
 Then run:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ We encourage people to share their custom models trained with Zamba. If you trai
 
 First, make sure you have the prerequisites installed:
 
-* Python >= 3.10
+* Python >= 3.11
 * FFmpeg > 4.3
 
 Then run:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ We encourage people to share their custom models trained with Zamba. If you trai
 
 First, make sure you have the prerequisites installed:
 
-* Python >= 3.11
+* Python 3.11 or 3.12
 * FFmpeg > 4.3
 
 Then run:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ We encourage people to share their custom models trained with Zamba. If you trai
 
 First, make sure you have the prerequisites installed:
 
-* Python 3.11 or 3.12
+* Python 3.11
 * FFmpeg > 4.3
 
 Then run:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ We encourage people to share their custom models trained with Zamba. If you trai
 
 First, make sure you have the prerequisites installed:
 
-* Python 3.8 or 3.9
+* Python >= 3.10
 * FFmpeg > 4.3
 
 Then run:

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -9,10 +9,10 @@ GPU configurations.
 
 Prerequisites:
 
- - Python 3.11 or 3.12
+ - Python 3.11
  - FFmpeg
 
-#### [Python](https://www.python.org/) 3.11 or 3.12
+#### [Python](https://www.python.org/) 3.11
 
 We recommend [Python installation using Anaconda](https://www.anaconda.com/download/) for all platforms. For more information about how to install Anaconda, here are some useful YouTube videos of installation:
 

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -9,10 +9,10 @@ GPU configurations.
 
 Prerequisites:
 
- - Python 3.8 or 3.9
+ - Python >= 3.10
  - FFmpeg
 
-#### [Python](https://www.python.org/) 3.8 or 3.9
+#### [Python](https://www.python.org/) >= 3.10
 
 We recommend [Python installation using Anaconda](https://www.anaconda.com/download/) for all platforms. For more information about how to install Anaconda, here are some useful YouTube videos of installation:
 

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -9,10 +9,10 @@ GPU configurations.
 
 Prerequisites:
 
- - Python >= 3.11
+ - Python 3.11 or 3.12
  - FFmpeg
 
-#### [Python](https://www.python.org/) >= 3.11
+#### [Python](https://www.python.org/) 3.11 or 3.12
 
 We recommend [Python installation using Anaconda](https://www.anaconda.com/download/) for all platforms. For more information about how to install Anaconda, here are some useful YouTube videos of installation:
 

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -9,10 +9,10 @@ GPU configurations.
 
 Prerequisites:
 
- - Python >= 3.10
+ - Python >= 3.11
  - FFmpeg
 
-#### [Python](https://www.python.org/) >= 3.10
+#### [Python](https://www.python.org/) >= 3.11
 
 We recommend [Python installation using Anaconda](https://www.anaconda.com/download/) for all platforms. For more information about how to install Anaconda, here are some useful YouTube videos of installation:
 

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -9,10 +9,10 @@ GPU configurations.
 
 Prerequisites:
 
- - Python 3.11
+ - Python 3.11 or 3.12
  - FFmpeg
 
-#### [Python](https://www.python.org/) 3.11
+#### [Python](https://www.python.org/) 3.11 or 3.12
 
 We recommend [Python installation using Anaconda](https://www.anaconda.com/download/) for all platforms. For more information about how to install Anaconda, here are some useful YouTube videos of installation:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
   "appdirs",
   "av",
@@ -38,7 +38,7 @@ dependencies = [
   "pytorchvideo",
   "scikit-learn",
   "tensorboard",
-  "thop==0.0.31.post2005241907",
+  "thop",
   "timm",
   "torch",
   "torchinfo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "appdirs",
   "av",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ tests = [
   "wheel",
 ]
 densepose = [
-  "torch<2.1.0",  # densepose broken after 2.1.0; https://github.com/facebookresearch/detectron2/issues/5110
+  "torch",
   "detectron2 @ git+https://github.com/facebookresearch/detectron2.git",
   "detectron2-densepose @ git+https://github.com/facebookresearch/detectron2@main#subdirectory=projects/DensePose"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.11,<=3.12"
 dependencies = [
   "appdirs",
   "av",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11"
 dependencies = [
   "appdirs",
   "av",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.11,<=3.12"
+requires-python = ">=3.11,<3.12"
 dependencies = [
   "appdirs",
   "av",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.11,<3.13"
 dependencies = [
   "appdirs",
   "av",

--- a/zamba/models/config.py
+++ b/zamba/models/config.py
@@ -428,7 +428,7 @@ class TrainConfig(ZambaBaseModel):
     data_dir: DirectoryPath = ""
     checkpoint: Optional[FilePath] = None
     scheduler_config: Optional[Union[str, SchedulerConfig]] = "default"
-    model_name: Optional[ModelEnum] = ModelEnum.time_distributed
+    model_name: Optional[ModelEnum] = ModelEnum.time_distributed.value
     dry_run: Union[bool, int] = False
     batch_size: int = 2
     auto_lr_find: bool = False
@@ -749,7 +749,7 @@ class PredictConfig(ZambaBaseModel):
     data_dir: DirectoryPath = ""
     filepaths: Optional[FilePath] = None
     checkpoint: Optional[FilePath] = None
-    model_name: Optional[ModelEnum] = ModelEnum.time_distributed
+    model_name: Optional[ModelEnum] = ModelEnum.time_distributed.value
     gpus: int = GPUS_AVAILABLE
     num_workers: int = 3
     batch_size: int = 2


### PR DESCRIPTION
PR to update the python required version to be >= 3.10 -- this required unpinning the `thop` dependency as well as changing the `ModelEnum.time_distributed` extraction of the string to `ModelEnum.time_distributed.value`.

Closes #310 
Closes #192 