### PR TITLE
Switch to jayqi/failed-build-issue-action

### DIFF
--- a/.github/failed_build_issue_template.md
+++ b/.github/failed_build_issue_template.md
@@ -1,5 +1,0 @@
----
-title: "Failed build on master branch ({{ env.WORKFLOW_NAME}} #{{ env.RUN_NUMBER }})"
-labels: bug
----
-Workflow failed: [{{ env.WORKFLOW_NAME}} #{{ env.RUN_NUMBER }}](https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,13 +177,6 @@ jobs:
     if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-          RUN_NUMBER: ${{ github.run_number}}
-          REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
+      - uses: jayqi/failed-build-issue-action@v1
         with:
-          filename: .github/failed_build_issue_template.md
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switches the failed build notification issue action to jayqi/failed-build-issue-action, which will reuse an already open issue and be less noisy.