### PR TITLE
Fix year in changelog and add missing file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
  - Fix bug that prevented loading checkpoints when model name was provided ([PR #359](https://github.com/drivendataorg/zamba/pull/359))
 
-## v.2.6.0 (2024-03-14)
+## v.2.6.0 (2025-03-14)
 
 * Added support for training and classifying on images ([PR #349](https://github.com/drivendataorg/zamba/pull/349))
 

--- a/docs/docs/changelog/index.md
+++ b/docs/docs/changelog/index.md
@@ -1,6 +1,10 @@
 # `zamba` changelog
 
-## v.2.6.0 (2024-09-27)
+## v.2.6.1 (2025-03-18)
+
+ - Fix bug that prevented loading checkpoints when model name was provided ([PR #359](https://github.com/drivendataorg/zamba/pull/359))
+
+## v.2.6.0 (2025-03-14)
 
 * Added support for training and classifying on images ([PR #349](https://github.com/drivendataorg/zamba/pull/349))
 


### PR DESCRIPTION
Looks like `make docs` wasn't run here: https://github.com/drivendataorg/zamba/commit/d8677fb2d8cc34eb19b93ee774e3f9991bbeb5b0