### PR TITLE
mark tests which require network connectivity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,4 +106,9 @@ allow_redefinition = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests/"]
-addopts = "--cov-append --cov=zamba --cov-report=term --cov-report=html --cov-report=xml -n=auto --report-log reportlog.jsonl"
+addopts = "-m 'not network and not cached' --cov-append --cov=zamba --cov-report=term --cov-report=html --cov-report=xml -n=auto --report-log reportlog.jsonl"
+markers = [
+    "network: Tests which require the use of a network connection",
+    "cached: Tests which require cached data files, which will be downloaded the first time they run",
+    "slow: Especially slow tests",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,7 @@ def pred_mock(self):
     return None
 
 
+@pytest.mark.network
 def test_train_specific_options(mocker, minimum_valid_train, tmp_path):  # noqa: F811
     mocker.patch("zamba.cli.ModelManager.train", train_mock)
 
@@ -57,7 +58,7 @@ def test_train_specific_options(mocker, minimum_valid_train, tmp_path):  # noqa:
     result = runner.invoke(app, minimum_valid_train + ["--save-dir", str(tmp_path)])
     assert result.exit_code == 0
 
-
+@pytest.mark.network
 def test_shared_cli_options(mocker, minimum_valid_train, minimum_valid_predict):  # noqa: F811
     """Test CLI options that are shared between train and predict commands."""
 
@@ -108,6 +109,7 @@ def test_shared_cli_options(mocker, minimum_valid_train, minimum_valid_predict):
         assert "Cannot use 2" in str(result.exc_info)
 
 
+@pytest.mark.cached
 def test_predict_specific_options(mocker, minimum_valid_predict, tmp_path):  # noqa: F811
     mocker.patch("zamba.cli.ModelManager.predict", pred_mock)
 
@@ -155,6 +157,7 @@ def test_predict_specific_options(mocker, minimum_valid_predict, tmp_path):  # n
 
 
 @pytest.mark.parametrize("model", ["time_distributed", "blank_nonblank"])
+@pytest.mark.network
 def test_actual_prediction_on_single_video(tmp_path, model):  # noqa: F811
     data_dir = tmp_path / "videos"
     data_dir.mkdir()
@@ -190,6 +193,7 @@ def test_actual_prediction_on_single_video(tmp_path, model):  # noqa: F811
     )
 
 
+@pytest.mark.network
 def test_actual_prediction_on_images(tmp_path, mocker):  # noqa: F811
     """Test predicting on images."""
     shutil.copytree(ASSETS_DIR / "images", tmp_path / "images")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,7 +39,7 @@ def test_train_data_dir_only():
         {"loc": ("labels",), "msg": "field required", "type": "value_error.missing"}
     ]
 
-
+@pytest.mark.cached
 def test_train_data_dir_and_labels(tmp_path, labels_relative_path, labels_absolute_path):
     # correct data dir
     config = TrainConfig(
@@ -64,11 +64,13 @@ def test_train_data_dir_and_labels(tmp_path, labels_relative_path, labels_absolu
     assert "None of the video filepaths exist" in error.value.errors()[0]["msg"]
 
 
+@pytest.mark.cached
 def test_train_labels_only(labels_absolute_path, tmp_path):
     config = TrainConfig(labels=labels_absolute_path, save_dir=tmp_path / "my_model")
     assert config.labels is not None
 
 
+@pytest.mark.cached
 def test_predict_data_dir_only():
     config = PredictConfig(data_dir=TEST_VIDEOS_DIR)
     assert config.data_dir == TEST_VIDEOS_DIR
@@ -79,6 +81,7 @@ def test_predict_data_dir_only():
     assert config.filepaths.columns == ["filepath"]
 
 
+@pytest.mark.cached
 def test_predict_data_dir_and_filepaths(labels_absolute_path, labels_relative_path):
     # correct data dir
     config = PredictConfig(data_dir=TEST_VIDEOS_DIR, filepaths=labels_relative_path)
@@ -92,11 +95,13 @@ def test_predict_data_dir_and_filepaths(labels_absolute_path, labels_relative_pa
     assert "None of the video filepaths exist" in error.value.errors()[0]["msg"]
 
 
+@pytest.mark.cached
 def test_predict_filepaths_only(labels_absolute_path):
     config = PredictConfig(filepaths=labels_absolute_path)
     assert config.filepaths is not None
 
 
+@pytest.mark.cached
 def test_filepath_column(tmp_path, labels_absolute_path):
     pd.read_csv(labels_absolute_path).rename(columns={"filepath": "video"}).to_csv(
         tmp_path / "bad_filepath_column.csv"
@@ -112,6 +117,7 @@ def test_filepath_column(tmp_path, labels_absolute_path):
     assert "must contain `filepath` and `label` columns" in error.value.errors()[0]["msg"]
 
 
+@pytest.mark.cached
 def test_label_column(tmp_path, labels_absolute_path):
     pd.read_csv(labels_absolute_path).rename(columns={"label": "animal"}).to_csv(
         tmp_path / "bad_label_column.csv"
@@ -121,6 +127,7 @@ def test_label_column(tmp_path, labels_absolute_path):
     assert "must contain `filepath` and `label` columns" in error.value.errors()[0]["msg"]
 
 
+@pytest.mark.cached
 def test_extra_column(tmp_path, labels_absolute_path):
     # add extra column that has species_ prefix
     df = pd.read_csv(labels_absolute_path)
@@ -148,6 +155,7 @@ def test_extra_column(tmp_path, labels_absolute_path):
     assert config.filepaths.columns == ["filepath"]
 
 
+@pytest.mark.cached
 def test_one_video_does_not_exist(tmp_path, labels_absolute_path, caplog):
     files_df = pd.read_csv(labels_absolute_path)
     # add a fake file
@@ -174,6 +182,7 @@ def test_one_video_does_not_exist(tmp_path, labels_absolute_path, caplog):
     assert len(config.labels) == (len(files_df) - 1)
 
 
+@pytest.mark.cached
 def test_videos_cannot_be_loaded(tmp_path, labels_absolute_path, caplog):
     files_df = pd.read_csv(labels_absolute_path)
     # create bad files
@@ -222,6 +231,7 @@ def test_early_stopping_mode():
     assert "Provided mode max is incorrect for val_loss monitor." == error.value.errors()[0]["msg"]
 
 
+@pytest.mark.cached
 def test_labels_with_all_null_species(labels_absolute_path, tmp_path):
     labels = pd.read_csv(labels_absolute_path)
     labels["label"] = np.nan
@@ -359,6 +369,7 @@ def test_from_scratch(labels_absolute_path, tmp_path, mock_download_weights, moc
     assert "If from_scratch=True, model_name cannot be None." == error.value.errors()[0]["msg"]
 
 
+@pytest.mark.cached
 def test_predict_dry_run_and_save(labels_absolute_path, caplog, tmp_path):
     config = PredictConfig(filepaths=labels_absolute_path, dry_run=True, save=True)
     assert (
@@ -373,6 +384,7 @@ def test_predict_dry_run_and_save(labels_absolute_path, caplog, tmp_path):
     assert config.save_dir is None
 
 
+@pytest.mark.cached
 def test_predict_filepaths_with_duplicates(labels_absolute_path, tmp_path, caplog):
     filepaths = pd.read_csv(labels_absolute_path, usecols=["filepath"])
     # add duplicate filepath
@@ -399,6 +411,7 @@ def test_model_cache_dir(
     assert config.model_cache_dir == tmp_path / "my_cache"
 
 
+@pytest.mark.cached
 def test_predict_save(labels_absolute_path, tmp_path, dummy_trained_model_checkpoint):
     # if save is True, save in current working directory
     config = PredictConfig(filepaths=labels_absolute_path, skip_load_validation=True)
@@ -456,6 +469,7 @@ def test_predict_save(labels_absolute_path, tmp_path, dummy_trained_model_checkp
     assert config.save_dir == save_dir
 
 
+@pytest.mark.cached
 def test_validate_scheduler(labels_absolute_path, tmp_path):
     # None gets transformed into SchedulerConfig
     config = TrainConfig(
@@ -500,6 +514,7 @@ def test_validate_scheduler(labels_absolute_path, tmp_path):
     )
 
 
+@pytest.mark.cached
 def test_dry_run_and_skip_load_validation(labels_absolute_path, caplog, tmp_path):
     # check dry_run is True sets skip_load_validation to True
     config = TrainConfig(
@@ -521,6 +536,7 @@ def test_dry_run_and_skip_load_validation(labels_absolute_path, caplog, tmp_path
     assert not config.skip_load_validation
 
 
+@pytest.mark.cached
 def test_default_video_loader_config(labels_absolute_path, tmp_path):
     # if no video loader is specified, use default for model
     config = ModelConfig(
@@ -557,6 +573,7 @@ def test_checkpoint_sets_model_to_default(
     assert config.model_name == "dummy_model"
 
 
+@pytest.mark.cached
 def test_validate_provided_species_and_use_default_model_labels(labels_absolute_path, tmp_path):
     # labels are subset of time distributed model
     config = TrainConfig(

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -1,9 +1,12 @@
 import itertools
 
+import pytest
+
 from zamba.pytorch.dataloaders import get_datasets
 from zamba.pytorch_lightning.video_modules import ZambaVideoDataModule
 
 
+@pytest.mark.cached
 def test_get_datasets_train_metadata(train_metadata):
     train_dataset, val_dataset, test_dataset, predict_dataset = get_datasets(
         train_metadata=train_metadata,
@@ -16,6 +19,7 @@ def test_get_datasets_train_metadata(train_metadata):
     assert predict_dataset is None
 
 
+@pytest.mark.cached
 def test_get_datasets_predict_metadata(predict_metadata):
     train_dataset, val_dataset, test_dataset, predict_dataset = get_datasets(
         predict_metadata=predict_metadata,
@@ -30,6 +34,7 @@ def test_get_datasets_predict_metadata(predict_metadata):
     assert test_dataset is None
 
 
+@pytest.mark.cached
 def test_get_datasets_train_and_predict_metadata(train_metadata, predict_metadata):
     train_dataset, val_dataset, test_dataset, predict_dataset = get_datasets(
         train_metadata=train_metadata,
@@ -45,6 +50,7 @@ def test_get_datasets_train_and_predict_metadata(train_metadata, predict_metadat
         assert label.sum() == 0
 
 
+@pytest.mark.cached
 def test_zamba_data_module_train(train_metadata):
     data_module = ZambaVideoDataModule(train_metadata=train_metadata)
     for videos, labels in data_module.train_dataloader():
@@ -52,6 +58,7 @@ def test_zamba_data_module_train(train_metadata):
         assert labels.sum() == 1
 
 
+@pytest.mark.cached
 def test_zamba_data_module_train_and_predict(train_metadata, predict_metadata):
     data_module = ZambaVideoDataModule(
         train_metadata=train_metadata,

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -26,6 +26,7 @@ def two_video_filepaths(tmp_path):
     return output_path
 
 
+@pytest.mark.cached
 def test_prediction(two_video_filepaths):
     dem = DepthEstimationManager(
         model_cache_dir=Path(appdirs.user_cache_dir()) / "zamba", gpus=GPUS_AVAILABLE
@@ -82,6 +83,7 @@ def test_save_dir_and_overwrite(tmp_path, two_video_filepaths):
     assert config.overwrite
 
 
+@pytest.mark.cached
 def test_invalid_video_is_skipped(tmp_path):
     # create invalid vid
     invalid_video = tmp_path / "invalid_vid.mp4"

--- a/tests/test_image_file_handling.py
+++ b/tests/test_image_file_handling.py
@@ -145,6 +145,7 @@ def ena24_dataset_setup(tmp_path):
 
 
 @pytest.mark.parametrize("input_format", ["relative_csv", "absolute_csv", "mixed_csv"])
+@pytest.mark.network
 def test_image_cli_with_paths(mocker, ena24_dataset_setup, input_format):
     """Test that the image CLI can handle a CSV with the specified path format."""
     predict_mock = mocker.patch("zamba.images.manager.ZambaImagesManager.predict")
@@ -211,6 +212,7 @@ def test_train_with_different_path_formats(mocker, ena24_dataset_setup, input_fo
     assert processed_images == expected_images
 
 
+@pytest.mark.network
 def test_image_cli_file_discovery(mocker, ena24_dataset_setup):
     """Test that the image CLI can discover files in a directory when no CSV is provided."""
     predict_mock = mocker.patch("zamba.images.manager.ZambaImagesManager.predict")
@@ -342,6 +344,7 @@ def test_train_with_md_labels(mocker, ena24_dataset_setup):
     )
 
 
+@pytest.mark.network
 def test_image_cli_csv_output(mocker, ena24_dataset_setup):
     """Test that the image CLI can output predictions in CSV format."""
 
@@ -402,6 +405,7 @@ def test_image_cli_csv_output(mocker, ena24_dataset_setup):
         assert species in predictions.columns
 
 
+@pytest.mark.network
 def test_image_cli_megadetector_output(mocker, ena24_dataset_setup):
     """Test that the image CLI can output predictions in MegaDetector JSON format."""
     # Mock detector

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -114,18 +114,21 @@ def test_image_annotation_crop_images_the_same_size(annotation, dog, trimmed_dog
     assert result.width == trimmed_dog.width
 
 
+@pytest.mark.cached
 def test_train_config_validate_labels_from_path(labels_path, images_path):
     config = ImageClassificationTrainingConfig(data_dir=images_path, labels=labels_path)
 
     assert isinstance(config.labels, pd.DataFrame)
 
 
+@pytest.mark.cached
 def test_train_config_labels(labels_path, images_path):
     config = ImageClassificationTrainingConfig(data_dir=images_path, labels=labels_path)
     logging.warning(config.labels.head())
     assert "label" in config.labels.columns
 
 
+@pytest.mark.cached
 def test_train_config_data_exist(labels_path, images_path):
     config = ImageClassificationTrainingConfig(data_dir=images_path, labels=labels_path)
 
@@ -207,6 +210,7 @@ def test_results_to_megadetector_format(dataframe_result_csv_path):
     assert len(result.images[1].detections) == 1
 
 
+@pytest.mark.network
 def test_train_integration(images_path, labels_path, dummy_checkpoint, tmp_path):
     save_dir = tmp_path / "my_model"
     checkpoint_path = tmp_path / "checkpoints"

--- a/tests/test_instantiate_model.py
+++ b/tests/test_instantiate_model.py
@@ -25,6 +25,7 @@ def test_scheduler_ignored_for_prediction(dummy_checkpoint):
     # # in Train Config, which contains ModelParams, labels cannot be None
 
 
+@pytest.mark.cached
 def test_default_scheduler_used(time_distributed_checkpoint):
     """Tests instantiate model uses the default scheduler from the hparams on the model."""
     default_scheduler_passed_model = instantiate_model(
@@ -40,6 +41,7 @@ def test_default_scheduler_used(time_distributed_checkpoint):
     )
 
 
+@pytest.mark.cached
 def test_scheduler_used_if_passed(time_distributed_checkpoint):
     """Tests that scheduler config gets used and overrides scheduler on time distributed training."""
     scheduler_passed_model = instantiate_model(
@@ -62,6 +64,7 @@ def test_scheduler_used_if_passed(time_distributed_checkpoint):
     assert scheduler_params_passed_model.hparams["scheduler_params"] == {"gamma": 0.3}
 
 
+@pytest.mark.cached
 def test_remove_scheduler(time_distributed_checkpoint):
     """Tests that a scheduler config with None values removes the scheduler on the model."""
     remove_scheduler_model = instantiate_model(
@@ -120,6 +123,7 @@ def test_not_use_default_model_labels(dummy_trained_model_checkpoint):
 @pytest.mark.parametrize(
     "model_name", ["time_distributed", "slowfast", "european", "blank_nonblank"]
 )
+@pytest.mark.cached
 def test_head_replaced_for_new_species(labels_absolute_path, model_name, tmp_path):
     """Check that output species reflect the new head."""
     # pick species that is not present in any models
@@ -143,6 +147,7 @@ def test_head_replaced_for_new_species(labels_absolute_path, model_name, tmp_pat
 
 
 @pytest.mark.parametrize("model_name", ["time_distributed", "slowfast", "european"])
+@pytest.mark.cached
 def test_resume_subset_labels(labels_absolute_path, model_name, tmp_path):
     """Check that output species reflect the default model labels."""
     # pick species that is present in all models

--- a/tests/test_load_video_frames.py
+++ b/tests/test_load_video_frames.py
@@ -384,6 +384,7 @@ def test_load_video_frames(case: Case, video_metadata: Dict[str, Any]):
                     assert video_shape[field] == value
 
 
+@pytest.mark.cached
 def test_same_filename_new_kwargs(tmp_path, train_metadata):
     """Test that load_video_frames does not load the npz file if the params change."""
     cache = tmp_path / "test_cache"
@@ -422,6 +423,7 @@ def test_same_filename_new_kwargs(tmp_path, train_metadata):
         assert first_load.shape != new_params_same_name.shape
 
 
+@pytest.mark.cached
 def test_megadetector_lite_yolox_dog(tmp_path):
     dog = Image.open(ASSETS_DIR / "dog.jpg")
     blank = Image.new("RGB", dog.size, (64, 64, 64))
@@ -517,6 +519,7 @@ def test_validate_total_frames():
     assert config.total_frames == 8
 
 
+@pytest.mark.cached
 def test_caching(tmp_path, caplog, train_metadata):
     cache = tmp_path / "video_cache"
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -182,7 +182,11 @@ def test_train_save_dir_overwrite(
     "model_name", ["time_distributed", "slowfast", "european", "blank_nonblank"]
 )
 @pytest.mark.parametrize("weight_region", ["us", "asia", "eu"])
+@pytest.mark.network
 def test_download_weights(model_name, weight_region, tmp_path):
+    """end-to-end test which performs a download of the weight files from
+    each AWS region.
+    """
     public_weights = get_model_checkpoint_filename(model_name)
 
     ckpt_path = download_weights(


### PR DESCRIPTION
Fixes: #389

- marks tests which always require network connections as 'network'
- marks tests which download cached data once as 'cached'