### PR TITLE
Release pre - test updates + version bumps

### DIFF
--- a/.github/MAINTAINING.md
+++ b/.github/MAINTAINING.md
@@ -6,7 +6,7 @@ This page contains documentation for Zamba maintainers.
 
 To release a new version of `zamba`:
 
-1. Bump the version in [`setup.cfg`](https://github.com/drivendataorg/zamba/blob/master/setup.cfg). The version number should follow [semantic versioning](https://semver.org/).
+1. Bump the version in `pyproject.toml`. The version number should follow [semantic versioning](https://semver.org/).
 2. Create a new release using the [GitHub releases UI](https://github.com/drivendataorg/zamba/releases/new). The tag version must have a prefix `v`, e.g., `v2.0.1`.
 
 On publishing of the release, the [`release`](https://github.com/drivendataorg/zamba/blob/master/.github/workflows/release.yml) GitHub action workflow will be triggered. This workflow builds the package and publishes it to PyPI. You will be able to see the workflow status in the [Actions tab](https://github.com/drivendataorg/zamba/actions?query=workflow%3Arelease).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # `zamba` changelog
 
-## Unreleased
+## v2.8.0 (2026-06-28)
 
  - Add the `speciesnet` image classification model, a `zamba`-compatible conversion of [Google's SpeciesNet](https://github.com/google/cameratrapai) classifier (EfficientNetV2-M backbone, 2,000+ class global taxonomy). Select it with `zamba image predict --model speciesnet` or `zamba image train --model speciesnet`. See the [Available Models](https://zamba.drivendata.org/docs/stable/models/image-classification/#speciesnet) page.
  - Persist the preprocessing `model_family` on image classifier checkpoints and derive inference transforms (resize size, interpolation, normalization) from the loaded checkpoint rather than from the `model_name` string. This fixes incorrect preprocessing (and near-random predictions) when running `zamba image predict --checkpoint <ckpt>` on a fine-tuned SpeciesNet model without also passing `--model`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "zamba"
-version = "2.7.0"
+version = "2.8.0"
 authors = [
   {name = "DrivenData", email = "info@drivendata.org"}
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def pred_mock(self):
 
 @pytest.mark.video
 def test_train_specific_options(mocker, minimum_valid_train, tmp_path):  # noqa: F811
-    mocker.patch("zamba.cli.ModelManager.train", train_mock)
+    mocker.patch("zamba.models.model_manager.ModelManager.train", train_mock)
 
     # check labels must exist
     result = runner.invoke(app, ["train", "--labels", "my_labels.csv"])
@@ -70,8 +70,8 @@ def test_train_specific_options(mocker, minimum_valid_train, tmp_path):  # noqa:
 def test_shared_cli_options(mocker, minimum_valid_train, minimum_valid_predict):  # noqa: F811
     """Test CLI options that are shared between train and predict commands."""
 
-    mocker.patch("zamba.cli.ModelManager.train", train_mock)
-    mocker.patch("zamba.cli.ModelManager.predict", pred_mock)
+    mocker.patch("zamba.models.model_manager.ModelManager.train", train_mock)
+    mocker.patch("zamba.models.model_manager.ModelManager.predict", pred_mock)
 
     for command in [minimum_valid_train, minimum_valid_predict]:
         # check default model is time distributed one
@@ -119,7 +119,7 @@ def test_shared_cli_options(mocker, minimum_valid_train, minimum_valid_predict):
 
 @pytest.mark.video
 def test_predict_specific_options(mocker, minimum_valid_predict, tmp_path):  # noqa: F811
-    mocker.patch("zamba.cli.ModelManager.predict", pred_mock)
+    mocker.patch("zamba.models.model_manager.ModelManager.predict", pred_mock)
 
     # check data dir must exist
     result = runner.invoke(app, ["predict", "--data-dir", "my_data"])

--- a/tests/test_extras_smoke.py
+++ b/tests/test_extras_smoke.py
@@ -1,0 +1,137 @@
+"""Smoke tests for optional image/video extra isolation.
+
+These tests are unmarked so they run in both ``make test-image-only`` and
+``make test-video-only`` (see pytest marker expression in the Makefile).
+
+Marked ``@pytest.mark.image`` / ``@pytest.mark.video`` tests exercise a real
+model end-to-end in the corresponding isolation venv.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from conftest import ASSETS_DIR, TEST_VIDEOS_DIR
+
+
+def _zamba_executable() -> list[str]:
+    """Use the zamba CLI from the same venv as the running interpreter."""
+    venv_zamba = Path(sys.executable).with_name("zamba")
+    if venv_zamba.exists():
+        return [str(venv_zamba)]
+    found = shutil.which("zamba")
+    assert found is not None
+    return [found]
+
+
+def test_zamba_cli_imports():
+    from zamba.cli import app
+
+    assert app is not None
+
+
+def test_image_subcommand_when_image_extra_installed():
+    pytest.importorskip("megadetector")
+
+    result = subprocess.run(
+        _zamba_executable() + ["image", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_video_predict_help():
+    result = subprocess.run(
+        _zamba_executable() + ["predict", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_image_cli_unavailable_without_image_extra():
+    try:
+        import megadetector  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        pytest.skip("image extra is installed")
+
+    result = subprocess.run(
+        _zamba_executable() + ["image", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+
+
+@pytest.mark.image
+def test_image_model_predict_smoke(tmp_path):
+    """Image-only install: run speciesnet inference on a single test image."""
+    pytest.importorskip("megadetector")
+
+    data_dir = tmp_path / "images"
+    data_dir.mkdir()
+    shutil.copy(ASSETS_DIR / "images" / "small_cat.jpg", data_dir)
+    save_dir = tmp_path / "out"
+
+    result = subprocess.run(
+        _zamba_executable()
+        + [
+            "image",
+            "predict",
+            "--data-dir",
+            str(data_dir),
+            "--model",
+            "speciesnet",
+            "--save-dir",
+            str(save_dir),
+            "--yes",
+            "--overwrite",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert (save_dir / "zamba_predictions.csv").exists()
+
+
+@pytest.mark.video
+def test_video_model_predict_smoke(tmp_path):
+    """Video-only install: run time_distributed inference (dry-run) on one clip."""
+    pytest.importorskip("ffmpeg")
+
+    video_src = TEST_VIDEOS_DIR / "data" / "raw" / "benjamin" / "04250002.MP4"
+    if not video_src.exists():
+        pytest.skip(f"test video not found: {video_src}")
+
+    data_dir = tmp_path / "videos"
+    data_dir.mkdir()
+    shutil.copy(video_src, data_dir)
+
+    result = subprocess.run(
+        _zamba_executable()
+        + [
+            "predict",
+            "--data-dir",
+            str(data_dir),
+            "--config",
+            str(ASSETS_DIR / "sample_predict_config.yaml"),
+            "--dry-run",
+            "--yes",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -169,7 +169,14 @@ def test_train_config_debug_with_no_matching_split_rows(labels_path, images_path
     assert (config.labels["split"] == "holdout").all()
 
 
-def test_predict_config_rejects_nonpositive_image_size(images_path):
+@pytest.fixture
+def isolated_cwd(tmp_path, monkeypatch):
+    """Keep predict-config tests off the repo root (save paths default to cwd)."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_predict_config_rejects_nonpositive_image_size(images_path, isolated_cwd):
     with pytest.raises(ValueError, match="Image size should be greater than 0"):
         ImageClassificationPredictConfig(
             data_dir=images_path,
@@ -323,7 +330,7 @@ def test_resolve_inference_family_falls_back_on_unreadable_checkpoint(tmp_path):
     assert resolve_inference_family("speciesnet", bad_ckpt) == "speciesnet"
 
 
-def test_predict_config_resolves_model_name_from_checkpoint_family(tmp_path, images_path):
+def test_predict_config_resolves_model_name_from_checkpoint_family(isolated_cwd, images_path):
     """An image checkpoint has no _default_model_name, so model_name falls back to the
     persisted preprocessing family rather than the (conflicting) passed model_name."""
     model = ImageClassifierModule(
@@ -333,7 +340,7 @@ def test_predict_config_resolves_model_name_from_checkpoint_family(tmp_path, ima
         model_name="resnet50",
         model_family="speciesnet",
     )
-    ckpt = tmp_path / "ck.ckpt"
+    ckpt = isolated_cwd / "ck.ckpt"
     model.to_disk(ckpt)
 
     config = ImageClassificationPredictConfig(

--- a/zamba/cli.py
+++ b/zamba/cli.py
@@ -10,7 +10,6 @@ import yaml
 
 from zamba import MODELS_DIRECTORY
 from zamba.models.config_common import ModelEnum, RegionEnum
-from zamba.models.model_manager import ModelManager
 from zamba.version import __version__
 
 try:
@@ -103,6 +102,7 @@ def train(
     """
     from zamba.data.video import VideoLoaderConfig
     from zamba.models.config import ModelConfig, TrainConfig
+    from zamba.models.model_manager import ModelManager
 
     if config is not None:
         with config.open() as f:
@@ -286,6 +286,7 @@ def predict(
     """
     from zamba.data.video import VideoLoaderConfig
     from zamba.models.config import ModelConfig, PredictConfig
+    from zamba.models.model_manager import ModelManager
 
     if config is not None:
         with config.open() as f:

--- a/zamba/images/config.py
+++ b/zamba/images/config.py
@@ -43,7 +43,8 @@ class ZambaImageConfig(ZambaBaseModel):
     def validate_save(cls, values):
         save_dir = values["save_dir"]
 
-        if save_dir is None:
+        # Only default to cwd when saving; predict configs may set save=False.
+        if save_dir is None and values.get("save", True):
             save_dir = Path.cwd()
 
         values["save_dir"] = save_dir
@@ -144,7 +145,7 @@ class ImageClassificationPredictConfig(ZambaImageConfig):
         if save_dir is None and save:
             save_dir = Path.cwd()
 
-        if save_dir is not None:
+        if save_dir is not None and save:
             # check if files exist
             save_path = save_dir / results_file_name
             if values["results_file_format"] == ResultsFormat.MEGADETECTOR:
@@ -156,10 +157,6 @@ class ImageClassificationPredictConfig(ZambaImageConfig):
 
             # make a directory if needed
             save_dir.mkdir(parents=True, exist_ok=True)
-
-            # set save to True if save_dir is set
-            if not save:
-                save = True
 
         values["save_dir"] = save_dir
         values["save"] = save


### PR DESCRIPTION
Prepares the v2.8.0 release: version bump, changelog, and fixes needed for PyPI publishing and optional-extra isolation.

 - Bump version to 2.8.0 in pyproject.toml and finalize the changelog entry (SpeciesNet model + checkpoint-driven preprocessing fix).
 - Fix image predict config so save=False does not default save_dir to cwd or force saving when a path is set.
 - Defer ModelManager import in CLI train/predict so the base package stays importable without video deps; update CLI test mocks accordingly.
 - Add test_extras_smoke.py for image/video extra isolation (CLI help, speciesnet predict smoke, video dry-run predict).
 - Update maintainer docs to point version bumps at pyproject.toml instead of setup.cfg.