### PR TITLE
V272

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # `zamba` changelog
 
+## v2.7.2 (2026-06-30)
+
+ - Fix single-GPU image training wrongly running under DDP when `devices="auto"`.
+ - Compile only the image backbone, not the whole module, so `torch.compile` no longer breaks training under DDP.
+ - Reconcile `_orig_mod.` checkpoint keys so compiled-model checkpoints load on any setup.
+
 ## v2.7.1 (2026-06-29)
 
  - Fix video and image training on PyTorch 2.7+ by dropping deprecated scheduler kwargs like `verbose`.

--- a/zamba/images/manager.py
+++ b/zamba/images/manager.py
@@ -398,11 +398,19 @@ def train(config: ImageClassificationTrainingConfig) -> pl.Trainer:
             batch_size=config.batch_size,
         )
 
-    # torch.compile is deferred until after batch-size / LR tuning below.
-    # Compiling before tuning breaks PyTorch Lightning's lr_find because self.log()
-    # introspects training_step via inspect, which torch dynamo cannot trace.
-    compile_enabled = sys.platform not in ("darwin", "win32")
+    # Compile only the inner backbone (not the whole LightningModule) for faster
+    # performance; disabled for MacOS and Windows (unsupported/unreliable). Compiling
+    # the LightningModule makes torch dynamo trace training_step, which calls
+    # self.log() and fails because Lightning introspects the hook with inspect.
     classifier = classifier_module
+    if sys.platform not in ("darwin", "win32"):
+        try:
+            torch._dynamo.config.cache_size_limit = (
+                16  # cache more functions than default 8 to avoid recompiling
+            )
+        except Exception:
+            logger.warning("Could not configure torch dynamo cache size limit")
+        classifier_module.model = torch.compile(classifier_module.model)
 
     # lower precision multiplication to speed up training
     try:
@@ -413,10 +421,16 @@ def train(config: ImageClassificationTrainingConfig) -> pl.Trainer:
     # Set log_every_n_steps to a reasonable value (e.g., 1/10th of batches, minimum of 1)
     log_every_n_steps = max(1, num_training_batches // 10)
 
-    # get the strategy based on devices
+    # Use DDP only for genuine multi-device runs. Note that `devices` may be the
+    # string "auto" (the default), which is iterable but NOT multi-device, so it must
+    # not fall into the Iterable branch below or single-GPU jobs wrongly run under DDP.
     if isinstance(config.devices, int) and config.devices > 1:
         strategy = "ddp"
-    elif isinstance(config.devices, Iterable) and len(config.devices) > 1:
+    elif (
+        not isinstance(config.devices, str)
+        and isinstance(config.devices, Iterable)
+        and len(list(config.devices)) > 1
+    ):
         strategy = "ddp"
     else:
         strategy = "auto"
@@ -473,15 +487,6 @@ def train(config: ImageClassificationTrainingConfig) -> pl.Trainer:
         classifier.hparams.lr = new_lr
 
     _save_config(classifier, config)
-
-    if compile_enabled:
-        try:
-            torch._dynamo.config.cache_size_limit = (
-                16  # cache more functions than default 8 to avoid recompiling
-            )
-        except Exception:
-            logger.warning("Could not configure torch dynamo cache size limit")
-        classifier = torch.compile(classifier_module)
 
     # Train with distributed training
     train_trainer.fit(

--- a/zamba/pytorch_lightning/base_module.py
+++ b/zamba/pytorch_lightning/base_module.py
@@ -98,28 +98,39 @@ class ZambaClassificationLightningModule(LightningModule):
         )
 
     def on_load_checkpoint(self, checkpoint):
-        """Some third-party models (notably speciesnet) save the model weights without the 'model.' prefix.
-        This function remaps the keys to add the 'model.' prefix so it is compatible with PyTorch Lightning.
+        """Remap checkpoint state_dict keys so they match the keys this module currently
+        expects. This reconciles two independent sources of key mismatch:
+
+        - ``torch.compile`` inserts an ``_orig_mod.`` segment (e.g.
+          ``model._orig_mod.stem.0.weight``). Depending on whether the *live* module is
+          compiled, the checkpoint may need that segment added or removed. We match on the
+          key with ``_orig_mod.`` removed, so it works in either direction (e.g. an
+          in-process lr_find restore of a compiled module, or predict-time loading of a
+          compiled checkpoint into an uncompiled module).
+        - Some third-party models (notably speciesnet) save the backbone weights without
+          the leading ``model.`` prefix.
         """
         sd = checkpoint.get("state_dict", {})
         if not sd:
             return
 
-        # Does this module expect 'model.'-prefixed keys?
         expected = self.state_dict()
-        expects_model_prefix = any(k.startswith("model.") for k in expected.keys())
-        has_model_prefix = any(k.startswith("model.") for k in sd.keys())
-        if not expects_model_prefix or has_model_prefix:
-            return
 
-        # Build a suffix set of the expected 'model.' parameters
-        expected_suffixes = {k[len("model.") :] for k in expected.keys() if k.startswith("model.")}
+        def normalize(key: str) -> str:
+            return key.replace("_orig_mod.", "")
 
-        # Prefix only the keys that map into the 'model.' subtree; leave others alone
+        # Map each expected key by its normalized (compile-agnostic) form so we can
+        # recover the exact key the live module wants regardless of compile state.
+        normalized_to_expected = {normalize(k): k for k in expected.keys()}
+
         remapped = {}
         for k, v in sd.items():
-            if k in expected_suffixes:
-                remapped[f"model.{k}"] = v
+            nk = normalize(k)
+            if nk in normalized_to_expected:
+                remapped[normalized_to_expected[nk]] = v
+            elif f"model.{nk}" in normalized_to_expected:
+                # checkpoint stored backbone weights without the 'model.' prefix
+                remapped[normalized_to_expected[f"model.{nk}"]] = v
             else:
                 remapped[k] = v
 


### PR DESCRIPTION
 - Fix single-GPU image training wrongly running under DDP when `devices="auto"`.
 - Compile only the image backbone, not the whole module, so `torch.compile` no longer breaks training under DDP.
 - Reconcile `_orig_mod.` checkpoint keys so compiled-model checkpoints load on any setup.