### PR TITLE
Skip ImageNet downloads when loading image checkpoints

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # `zamba` changelog
 
+## Unreleased
+
+ - Skip downloading ImageNet/timm pretrained weights when loading or finetuning from an image checkpoint (e.g. official `lila.science` or `speciesnet`); those weights were immediately overwritten by the checkpoint ([PR #407](https://github.com/drivendataorg/zamba/pull/407)).
+
 ## v2.7.2 (2026-06-30)
 
  - Fix single-GPU image training wrongly running under DDP when `devices="auto"`.

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -233,6 +233,34 @@ def test_save_and_load(model_class, tmp_path):
     assert model.num_classes == 2
 
 
+def test_image_classifier_from_disk_does_not_request_pretrained_weights(monkeypatch, tmp_path):
+    pretrained_values = []
+
+    def fake_create_model(model_name, pretrained, num_classes):
+        pretrained_values.append(pretrained)
+        return torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, num_classes))
+
+    monkeypatch.setattr("zamba.images.classifier.timm.create_model", fake_create_model)
+
+    model = ImageClassifierModule(
+        species=["cat", "dog"], batch_size=2, image_size=224, model_name="tiny"
+    )
+    path = tmp_path / "tiny.ckpt"
+    model.to_disk(path)
+
+    ImageClassifierModule.from_disk(path)
+    # Finetuning official checkpoints goes through from_disk as well.
+    ImageClassifierModule(
+        species=["cat", "dog"],
+        batch_size=2,
+        image_size=224,
+        model_name="tiny",
+        finetune_from=path,
+    )
+
+    assert pretrained_values == [True, False, False]
+
+
 @pytest.mark.parametrize(
     "name,expected",
     [

--- a/zamba/images/classifier.py
+++ b/zamba/images/classifier.py
@@ -44,6 +44,7 @@ class ImageClassifierModule(ZambaClassificationLightningModule):
         scheduler: Optional[LRScheduler] = None,
         scheduler_params: Optional[dict] = None,
         model_family: Optional[str] = None,
+        pretrained: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -68,7 +69,7 @@ class ImageClassifierModule(ZambaClassificationLightningModule):
 
         if finetune_from is None:
             self.model = timm.create_model(
-                self.base_model_name, pretrained=True, num_classes=self.num_classes
+                self.base_model_name, pretrained=pretrained, num_classes=self.num_classes
             )
         else:
             self.model = self.from_disk(finetune_from, batch_size=batch_size, **kwargs).model
@@ -100,6 +101,12 @@ class ImageClassifierModule(ZambaClassificationLightningModule):
         # store the *resolved* family (save_hyperparameters would capture the raw arg,
         # which may be None before inference)
         self.hparams["model_family"] = self.model_family
+
+    @classmethod
+    def from_disk(cls, path: os.PathLike, **kwargs):
+        # Checkpoint weights replace the backbone; never pull ImageNet/timm weights.
+        kwargs["pretrained"] = False
+        return super().from_disk(path, **kwargs)
 
     def configure_optimizers(self):
         # Use Adam optimizer


### PR DESCRIPTION
## Summary
- Loading or finetuning from a checkpoint (e.g. official lila.science / speciesnet) no longer requests timm ImageNet weights from Hugging Face; those weights were immediately overwritten by the checkpoint.
- `ImageClassifierModule.from_disk` forces `pretrained=False`; from-scratch training still defaults to `pretrained=True`.
- Adds a unit test covering `from_disk` and `finetune_from`.

## Test plan
- [x] `pytest tests/test_images.py::test_image_classifier_from_disk_does_not_request_pretrained_weights`
- [x] Finetune from official `lila.science` or `speciesnet` and confirm no Hugging Face ImageNet download in the logs


Made with [Cursor](https://cursor.com)