### PR TITLE
Preserve image fine-tuning labels

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
  - Skip downloading ImageNet/timm pretrained weights when loading or finetuning from an image checkpoint (e.g. official `lila.science` or `speciesnet`); those weights were immediately overwritten by the checkpoint ([PR #407](https://github.com/drivendataorg/zamba/pull/407)).
+ - Preserve user-provided labels in image fine-tuning checkpoints and prediction outputs instead of exposing the temporary `species_` one-hot prefix.
 
 ## v2.7.2 (2026-06-30)
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -27,6 +27,7 @@ from zamba.images.manager import (  # noqa: E402
     train,
 )
 from zamba.images.result import results_to_megadetector_format  # noqa: E402
+from zamba.models.instantiation import instantiate_model  # noqa: E402
 
 from conftest import ASSETS_DIR, DummyZambaImageClassificationLightningModule  # noqa: E402
 
@@ -139,6 +140,53 @@ def test_train_config_labels(labels_path, images_path):
     logging.warning(config.labels.head())
     assert "label" in config.labels.columns
     assert config.species_in_label_order == ["cat", "chimpanzee", "wild_dog"]
+
+
+def test_train_config_preserves_user_label_names_and_target_order(images_path):
+    user_labels = ["Wild Dog", "Cat", "Chimpanzee"]
+    labels = pd.DataFrame(
+        {
+            "filepath": [
+                "images/wild_dog_jackal.jpg",
+                "images/small_cat.jpg",
+                "images/chimpanzee_bonobo.jpeg",
+            ],
+            "label": user_labels,
+            "split": "train",
+        }
+    )
+
+    config = ImageClassificationTrainingConfig(data_dir=images_path, labels=labels)
+
+    assert config.species_in_label_order == ["Cat", "Chimpanzee", "Wild Dog"]
+    assert [
+        config.species_in_label_order[index] for index in config.labels["label"]
+    ] == user_labels
+    assert labels["label"].tolist() == user_labels
+
+
+def test_train_config_rejects_labels_that_differ_only_by_case(images_path):
+    labels = pd.DataFrame(
+        {
+            "filepath": ["images/small_cat.jpg", "images/wild_dog_jackal.jpg"],
+            "label": ["Fox", "fox"],
+            "split": "train",
+        }
+    )
+
+    with pytest.raises(ValueError, match="differ only by case"):
+        ImageClassificationTrainingConfig(data_dir=images_path, labels=labels)
+
+
+def test_finetuning_uses_case_insensitive_subset_matching(dummy_checkpoint):
+    model = instantiate_model(
+        checkpoint=dummy_checkpoint,
+        labels=pd.DataFrame(),
+        species=["Cat"],
+        use_default_model_labels=True,
+    )
+
+    assert model.species == ["cat", "wild_dog", "chimpanzee", "lion"]
 
 
 def test_normalize_prediction_labels_preserves_new_and_normalizes_legacy_labels():
@@ -526,10 +574,14 @@ def test_train_integration(
 ):
     save_dir = tmp_path / "my_model"
     checkpoint_path = tmp_path / "checkpoints"
+    labels = pd.read_csv(labels_path)
+    labels["label"] = labels["label"].replace(
+        {"cat": "Cat", "wild_dog": "Wild Dog", "chimpanzee": "Chimpanzee", "lion": "Lion"}
+    )
 
     config = ImageClassificationTrainingConfig(
         data_dir=images_path,
-        labels=labels_path,
+        labels=labels,
         model_name="dummy",
         max_epochs=1,
         batch_size=1,

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -20,6 +20,8 @@ from zamba.images.data import absolute_bbox  # noqa: E402
 from zamba.images.dataset.dataset import crop_image, prepare_dataset  # noqa: E402
 from zamba.images.manager import (  # noqa: E402
     get_default_transforms,
+    get_prediction_labels,
+    normalize_prediction_labels,
     resolve_inference_family,
     resolve_training_image_size,
     train,
@@ -136,6 +138,26 @@ def test_train_config_labels(labels_path, images_path):
     config = ImageClassificationTrainingConfig(data_dir=images_path, labels=labels_path)
     logging.warning(config.labels.head())
     assert "label" in config.labels.columns
+    assert config.species_in_label_order == ["cat", "chimpanzee", "wild_dog"]
+
+
+def test_normalize_prediction_labels_preserves_new_and_normalizes_legacy_labels():
+    assert normalize_prediction_labels(["cat", "species_wild_dog", "species_species_fox"]) == [
+        "cat",
+        "wild_dog",
+        "species_fox",
+    ]
+
+    legacy_checkpoint = SimpleNamespace(
+        species=["species_wild_dog"], hparams={"species": ["species_wild_dog"]}
+    )
+    assert get_prediction_labels(legacy_checkpoint) == ["wild_dog"]
+
+    new_checkpoint = SimpleNamespace(
+        species=["species_wild_dog"],
+        hparams={"species": ["species_wild_dog"], "species_labels_are_user_provided": True},
+    )
+    assert get_prediction_labels(new_checkpoint) == ["species_wild_dog"]
 
 
 def test_train_config_data_exist(labels_path, images_path):
@@ -516,6 +538,7 @@ def test_train_integration(
         from_scratch=False,
         save_dir=save_dir,
         extra_train_augmentations=extra_train_augmentations,
+        num_workers=0,
     )
 
     train(config)
@@ -523,3 +546,7 @@ def test_train_integration(
 
     for f in ["train_configuration.yaml", "val_metrics.json", f"{config.model_name}.ckpt"]:
         assert (config.save_dir / f).exists()
+
+    checkpoint = torch.load(config.save_dir / f"{config.model_name}.ckpt", weights_only=False)
+    assert checkpoint["hyper_parameters"]["species"] == config.species_in_label_order
+    assert checkpoint["hyper_parameters"]["species_labels_are_user_provided"] is True

--- a/zamba/images/config.py
+++ b/zamba/images/config.py
@@ -412,10 +412,36 @@ class ImageClassificationTrainingConfig(ZambaImageConfig):
     def preprocess_labels(cls, values):
         """One hot encode and add splits."""
         logger.info("Preprocessing labels.")
-        labels = values["labels"]
+        labels = values["labels"].copy()
+
+        # Preserve the user-facing label names for checkpoints and predictions. The
+        # normalized names below remain an internal implementation detail used for
+        # one-hot encoding and numeric target creation.
+        user_labels = labels["label"].copy()
+        normalized_labels = user_labels.str.lower()
+        display_labels_by_normalized_name = pd.DataFrame(
+            {"normalized": normalized_labels, "display": user_labels}
+        )
+
+        case_collisions = display_labels_by_normalized_name.groupby("normalized")[
+            "display"
+        ].nunique()
+        case_collisions = case_collisions[case_collisions > 1]
+        if not case_collisions.empty:
+            ambiguous_labels = display_labels_by_normalized_name[
+                display_labels_by_normalized_name["normalized"].isin(case_collisions.index)
+            ]["display"].drop_duplicates()
+            raise ValueError(
+                "Labels that differ only by case are not supported: "
+                f"{ambiguous_labels.tolist()}"
+            )
+
+        display_labels_by_normalized_name = display_labels_by_normalized_name.drop_duplicates(
+            "normalized"
+        ).set_index("normalized")["display"]
 
         # lowercase to facilitate subset checking
-        labels["label"] = labels.label.str.lower()
+        labels["label"] = normalized_labels
 
         # one hot encoding
         labels = pd.get_dummies(labels.rename(columns={"label": "species"}), columns=["species"])
@@ -425,10 +451,11 @@ class ImageClassificationTrainingConfig(ZambaImageConfig):
         # with missing examples.
         species_columns = labels.columns[labels.columns.str.startswith("species_")]
         # ``species_`` is an implementation detail of the temporary one-hot encoding.
-        # Keep those columns for constructing numeric targets, but save the labels users
-        # supplied in the checkpoint so they are also used in prediction outputs.
+        # Keep those columns for numeric targets, and map their order back to the
+        # original labels so checkpoint outputs align with those target indices.
         values["species_in_label_order"] = [
-            column.removeprefix("species_") for column in species_columns
+            display_labels_by_normalized_name[column.removeprefix("species_")]
+            for column in species_columns
         ]
 
         indices = (

--- a/zamba/images/config.py
+++ b/zamba/images/config.py
@@ -423,8 +423,13 @@ class ImageClassificationTrainingConfig(ZambaImageConfig):
         # We validate that all the images exist prior to this, so once this assembles the set of classes,
         # we should have at least one example of each label and don't need to worry about filtering out classes
         # with missing examples.
-        species_columns = labels.columns[labels.columns.str.contains("species_")]
-        values["species_in_label_order"] = species_columns.to_list()
+        species_columns = labels.columns[labels.columns.str.startswith("species_")]
+        # ``species_`` is an implementation detail of the temporary one-hot encoding.
+        # Keep those columns for constructing numeric targets, but save the labels users
+        # supplied in the checkpoint so they are also used in prediction outputs.
+        values["species_in_label_order"] = [
+            column.removeprefix("species_") for column in species_columns
+        ]
 
         indices = (
             labels[species_columns].idxmax(axis=1).apply(lambda x: species_columns.get_loc(x))
@@ -468,9 +473,7 @@ class ImageClassificationTrainingConfig(ZambaImageConfig):
 
         values["labels"] = labels.reset_index()
 
-        example_species = [
-            species.replace("species_", "") for species in values["species_in_label_order"][:3]
-        ]
+        example_species = values["species_in_label_order"][:3]
         logger.info(
             f"Labels preprocessed. {len(values['species_in_label_order'])} species found: {example_species}..."
         )

--- a/zamba/images/manager.py
+++ b/zamba/images/manager.py
@@ -237,9 +237,7 @@ def predict(config: ImageClassificationPredictConfig) -> None:
             save_path = save_path.with_suffix(".csv")
             df.to_csv(save_path, index=False)
         elif config.results_file_format == ResultsFormat.MEGADETECTOR:
-            megadetector_format_results = results_to_megadetector_format(
-                df, output_species
-            )
+            megadetector_format_results = results_to_megadetector_format(df, output_species)
             save_path = save_path.with_suffix(".json")
             with open(save_path, "w") as f:
                 json.dump(megadetector_format_results.dict(), f)

--- a/zamba/images/manager.py
+++ b/zamba/images/manager.py
@@ -73,6 +73,18 @@ def get_weights(split):
     return torch.tensor(class_weights).to(torch.float32)
 
 
+def normalize_prediction_labels(species: list[str]) -> list[str]:
+    """Remove the legacy one-hot-encoding prefix from checkpoint labels."""
+    return [label.removeprefix("species_") for label in species]
+
+
+def get_prediction_labels(classifier_module) -> list[str]:
+    """Return user-facing labels for new and legacy image checkpoints."""
+    if classifier_module.hparams.get("species_labels_are_user_provided", False):
+        return classifier_module.species
+    return normalize_prediction_labels(classifier_module.species)
+
+
 def get_default_transforms(model_family: str, image_size=None):
     """Build the (top, bottom) eval transform lists for a preprocessing family.
 
@@ -149,6 +161,7 @@ def predict(config: ImageClassificationPredictConfig) -> None:
         checkpoint=config.checkpoint,
     )
     classifier_module.eval()
+    output_species = get_prediction_labels(classifier_module)
 
     # The loaded checkpoint is the source of truth for preprocessing. Derive the family
     # (and image size) from the module rather than from config.model_name, which is
@@ -212,7 +225,7 @@ def predict(config: ImageClassificationPredictConfig) -> None:
 
         # Split result into separate columns for each class using "species" from classifier module
         species_df = pd.DataFrame(df["result"].tolist(), index=df.index)
-        species_df.columns = classifier_module.species
+        species_df.columns = output_species
         df = pd.concat([df, species_df], axis=1)
 
         # Drop the original 'bbox' and 'result' columns
@@ -225,7 +238,7 @@ def predict(config: ImageClassificationPredictConfig) -> None:
             df.to_csv(save_path, index=False)
         elif config.results_file_format == ResultsFormat.MEGADETECTOR:
             megadetector_format_results = results_to_megadetector_format(
-                df, classifier_module.species
+                df, output_species
             )
             save_path = save_path.with_suffix(".json")
             with open(save_path, "w") as f:
@@ -397,6 +410,11 @@ def train(config: ImageClassificationTrainingConfig) -> pl.Trainer:
             species=config.species_in_label_order,
             batch_size=config.batch_size,
         )
+
+    # New checkpoints store the original label names rather than the temporary
+    # one-hot column names. This distinguishes them from legacy checkpoints whose
+    # labels need output-time normalization.
+    classifier_module.hparams["species_labels_are_user_provided"] = True
 
     # Compile only the inner backbone (not the whole LightningModule) for faster
     # performance; disabled for MacOS and Windows (unsupported/unreliable). Compiling

--- a/zamba/models/instantiation.py
+++ b/zamba/models/instantiation.py
@@ -21,6 +21,13 @@ def _apply_scheduler_config(hparams, scheduler_config):
         hparams.update(scheduler_config.dict())
 
 
+def _species_are_subset(species, model_species):
+    """Compare labels using the normalization applied during image training."""
+    return {label.lower() for label in species}.issubset(
+        {label.lower() for label in model_species}
+    )
+
+
 def instantiate_model(
     checkpoint: os.PathLike,
     labels: Optional[pd.DataFrame] = None,
@@ -73,7 +80,7 @@ def instantiate_model(
         return model
 
     # finetuning / resume
-    is_subset = set(species).issubset(set(hparams["species"]))
+    is_subset = _species_are_subset(species, hparams["species"])
 
     if is_subset:
         if use_default_model_labels:


### PR DESCRIPTION
Store original image fine-tuning labels in newly trained checkpoints while retaining temporary one-hot columns for numeric targets. Normalize labels only for legacy checkpoints at prediction time; a checkpoint marker preserves user labels that themselves begin with `species_`. Tests cover label persistence and legacy output compatibility, including the image training integration test.