### PR TITLE
Fix image train --batch-size being silently ignored

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+ - Fix `zamba image train --batch-size` (and yaml `batch_size`) being ignored; the CLI was dropping the value before config construction.
  - Skip downloading ImageNet/timm pretrained weights when loading or finetuning from an image checkpoint (e.g. official `lila.science` or `speciesnet`); those weights were immediately overwritten by the checkpoint ([PR #407](https://github.com/drivendataorg/zamba/pull/407)).
 
 ## v2.7.2 (2026-06-30)

--- a/tests/test_image_file_handling.py
+++ b/tests/test_image_file_handling.py
@@ -213,6 +213,38 @@ def test_train_with_different_path_formats(mocker, ena24_dataset_setup, input_fo
     assert processed_images == expected_images
 
 
+def test_train_cli_respects_batch_size(mocker, ena24_dataset_setup):
+    """--batch-size must reach the training config (was silently dropped from to_drop)."""
+    train_mock = mocker.patch("zamba.images.manager.ZambaImagesManager.train")
+
+    result = runner.invoke(
+        image_app,
+        [
+            "train",
+            "--data-dir",
+            str(ena24_dataset_setup["data_dir"]),
+            "--labels",
+            str(ena24_dataset_setup["relative_labels"]),
+            "--save-dir",
+            str(ena24_dataset_setup["save_dir"]),
+            "--cache-dir",
+            str(ena24_dataset_setup["cache_dir"]),
+            "--checkpoint-path",
+            str(ena24_dataset_setup["checkpoint_dir"]),
+            "--from-scratch",
+            "--batch-size",
+            "1",
+            "--max-epochs",
+            "1",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    train_mock.assert_called_once()
+    assert train_mock.call_args[0][0].batch_size == 1
+
+
 def test_image_cli_file_discovery(mocker, ena24_dataset_setup):
     """Test that the image CLI can discover files in a directory when no CSV is provided."""
     predict_mock = mocker.patch("zamba.images.manager.ZambaImagesManager.predict")

--- a/zamba/image_cli.py
+++ b/zamba/image_cli.py
@@ -302,7 +302,6 @@ def train(
             "debug": lambda x: ("debug", x if isinstance(x, int) and x > 0 else None),
         },
         to_drop=[
-            "batch_size",
             "config",
             "mlflow_experiment_name",
             "model",


### PR DESCRIPTION
## Summary
`zamba image train` was dropping `batch_size` in `consolidate_options` before building the config, so `--batch-size` and yaml `batch_size` always fell back to the default of 16. Remove it from the train `to_drop` list and add a CLI regression test.

## Test plan
- [x] `pytest tests/test_image_file_handling.py::test_train_cli_respects_batch_size`
- [ ] Smoke: `zamba image train ... --batch-size 1` and confirm the confirmation dump shows `Batch size: 1`


Made with [Cursor](https://cursor.com)