### PR TITLE
Fix MegaDetector JSON output: string-int classification categories, rounding, indentation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+ - Fix MegaDetector-format image prediction output: classification categories are now emitted as string-ints (e.g. `"10"`) to match the keys in `classification_categories` and the (already correct) detection categories, per the MD spec. Also round confidence and bounding-box values to 4 decimal places and indent the JSON for readability.
  - Fix `zamba image train --batch-size` (and yaml `batch_size`) being ignored; the CLI was dropping the value before config construction.
  - Skip downloading ImageNet/timm pretrained weights when loading or finetuning from an image checkpoint (e.g. official `lila.science` or `speciesnet`); those weights were immediately overwritten by the checkpoint ([PR #407](https://github.com/drivendataorg/zamba/pull/407)).
  - Preserve user-provided labels in image fine-tuning checkpoints and prediction outputs instead of exposing the temporary `species_` one-hot prefix.

--- a/tests/test_image_file_handling.py
+++ b/tests/test_image_file_handling.py
@@ -497,3 +497,7 @@ def test_image_cli_megadetector_output(mocker, ena24_dataset_setup):
 
     classification = detection["classifications"][0]
     assert len(classification) == 2
+    # Classification category must be a string-int to match the keys in
+    # classification_categories (like detection categories), per the MD spec.
+    assert isinstance(classification[0], str)
+    assert classification[0] in predictions["classification_categories"]

--- a/zamba/images/manager.py
+++ b/zamba/images/manager.py
@@ -240,7 +240,7 @@ def predict(config: ImageClassificationPredictConfig) -> None:
             megadetector_format_results = results_to_megadetector_format(df, output_species)
             save_path = save_path.with_suffix(".json")
             with open(save_path, "w") as f:
-                json.dump(megadetector_format_results.dict(), f)
+                json.dump(megadetector_format_results.dict(), f, indent=1)
         logger.info(f"Results saved to {save_path}")
 
 

--- a/zamba/images/result.py
+++ b/zamba/images/result.py
@@ -29,13 +29,16 @@ class ClassificationResultMegadetectorFormat(BaseModel):
 def get_top_3_classifications(row, species) -> list:
     row_to_compare = row[species]
     row_to_compare = pd.to_numeric(row_to_compare, errors="coerce")
-    return [[species.index(col), value] for col, value in row_to_compare.nlargest(3).items()]
+    return [
+        [str(species.index(col)), round(float(value), 4)]
+        for col, value in row_to_compare.nlargest(3).items()
+    ]
 
 
 def results_to_megadetector_format(
     df: pd.DataFrame, species: list
 ) -> ClassificationResultMegadetectorFormat:
-    classification_categories = {idx: specie for idx, specie in enumerate(species)}
+    classification_categories = {str(idx): specie for idx, specie in enumerate(species)}
     info = {}
     detection_categories = {"1": "animal", "2": "person", "3": "vehicle"}
 
@@ -57,12 +60,12 @@ def results_to_megadetector_format(
         image_results[filepath].detections.append(
             ImageDetectionResult(
                 category=detection_category,
-                conf=row["detection_conf"],
+                conf=round(float(row["detection_conf"]), 4),
                 bbox=[
-                    row["x1"] / width,
-                    row["y1"] / height,
-                    (row["x2"] - row["x1"]) / width,
-                    (row["y2"] - row["y1"]) / height,
+                    round(row["x1"] / width, 4),
+                    round(row["y1"] / height, 4),
+                    round((row["x2"] - row["x1"]) / width, 4),
+                    round((row["y2"] - row["y1"]) / height, 4),
                 ],  # MegaDetector bbox is relative measures from top left [x1, y1, width, height]
                 classifications=detection_classifications,
             )


### PR DESCRIPTION
Fixes three issues reported by a MegaDetector expert with the `--output-format megadetector` image prediction JSON.

- **Bug:** classification categories were emitted as ints (`[10, 0.379...]`) while their keys in `classification_categories` are string-ints; they are now string-ints (`["10", 0.379...]`) to match the keys and the (already correct) detection categories, per the MD spec.
- Round confidence and bounding-box values to 4 decimal places, and indent the JSON (`indent=1`, matching MegaDetector's own convention) so files are more readable and compact.
- Also make `classification_categories` keys explicitly `str(idx)` for robustness, and add test assertions locking in the string-int category behavior.

Verified with `pytest tests/test_image_file_handling.py::test_image_cli_megadetector_output` against the real `[image]` extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)